### PR TITLE
Fix: Some options of User are not optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     ],
     "reporter": [
       "text-summary",
-      "html",
       "json",
       "lcov"
     ],

--- a/src/RolloutEvaluator.ts
+++ b/src/RolloutEvaluator.ts
@@ -20,13 +20,13 @@ export class User {
     identifier: string;
 
     /** Optional parameter for easier targeting rule definitions */
-    email: string;
+    email?: string;
 
     /** Optional parameter for easier targeting rule definitions */
-    country: string;
+    country?: string;
 
     /** Optional dictionary for custom attributes of the User for advanced targeting rule definitions. e.g. User role, Subscription type */
-    custom: { [key: string]: string } = {};
+    custom?: { [key: string]: string } = {};
 }
 
 export class RolloutEvaluator implements IRolloutEvaluator {

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -50,7 +50,7 @@ describe("ConfigCatClient", () => {
     }).to.throw("Invalid 'configCatKernel.cache' value");
   }); 
   
-  it("Initialization With AutoPollOptions should create an istance, GetValue works", (done) => {
+  it("Initialization With AutoPollOptions should create an instance, GetValue works", (done) => {
     let configCatKernel: FakeConfigCatKernel = {configFetcher: new FakeConfigFetcher(), cache: new InMemoryCache()};
     let options: AutoPollOptions = new AutoPollOptions("APIKEY", {logger: null})
     let client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
@@ -83,7 +83,7 @@ describe("ConfigCatClient", () => {
     });
   });
 
-  it("Initialization With LazyLoadOptions should create an istance", (done) => {
+  it("Initialization With LazyLoadOptions should create an instance", (done) => {
 
     let configCatKernel: FakeConfigCatKernel = {configFetcher: new FakeConfigFetcher(), cache: new InMemoryCache()};
     let options: LazyLoadOptions = new LazyLoadOptions("APIKEY", {logger: null})
@@ -110,7 +110,7 @@ describe("ConfigCatClient", () => {
       }, new User("identifier"));
   });
 
-  it("Initialization With ManualPollOptions should create an istance", (done) => {
+  it("Initialization With ManualPollOptions should create an instance", (done) => {
 
     let configCatKernel: FakeConfigCatKernel = {configFetcher: new FakeConfigFetcher(), cache: new InMemoryCache()};
     let options: ManualPollOptions = new ManualPollOptions("APIKEY", {logger: null})
@@ -143,8 +143,7 @@ describe("ConfigCatClient", () => {
     });
   });
 
-
-  it("Initialization With ManualPollOptions should create an istance", (done) => {
+  it("Initialization With ManualPollOptions should create an instance", (done) => {
 
     let configCatKernel: FakeConfigCatKernel = {configFetcher: new FakeConfigFetcherWithNullNewConfig(), cache: new InMemoryCache()};
     let options: ManualPollOptions = new ManualPollOptions("APIKEY", {logger: null})
@@ -157,7 +156,7 @@ describe("ConfigCatClient", () => {
     });
   });
 
-  it("Initialization With AutoPollOptions should create an istance", (done) => {
+  it("Initialization With AutoPollOptions should create an instance", (done) => {
 
     let configCatKernel: FakeConfigCatKernel = {configFetcher: new FakeConfigFetcherWithNullNewConfig(), cache: new InMemoryCache()};
     let options: ManualPollOptions = new AutoPollOptions("APIKEY", {logger: null})
@@ -171,7 +170,7 @@ describe("ConfigCatClient", () => {
   });
 
   
-  it("Initialization With LazyLoadOptions should create an istance", (done) => {
+  it("Initialization With LazyLoadOptions should create an instance", (done) => {
 
     let configCatKernel: FakeConfigCatKernel = {configFetcher: new FakeConfigFetcherWithNullNewConfig(), cache: new InMemoryCache()};
     let options: ManualPollOptions = new LazyLoadOptions("APIKEY", {logger: null})
@@ -182,6 +181,21 @@ describe("ConfigCatClient", () => {
       assert.equal(false, value);
       done();
     });
+  });
+
+  it("ConfigCatClient.getValue works without optional user info", (done) => {
+
+    let configCatKernel: FakeConfigCatKernel = {configFetcher: new FakeConfigFetcherWithNullNewConfig(), cache: new InMemoryCache()};
+    let options: ManualPollOptions = new AutoPollOptions("APIKEY", {logger: null})
+    let client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
+    let myUser = { identifier: "IDENTIFIER" };
+    assert.isDefined(client);
+
+    client.getValue("debug", false, function(value) {
+      assert.equal(false, value);
+      done();
+    },
+    myUser);
   });
 
 });


### PR DESCRIPTION
Following code shown on dashboard doesn't run on TypeScript because `myUser`'s options (`identifier`, `email`, `country` and `custom`) are all required due to the lack of `?` on [User](https://github.com/configcat/common-js/blob/master/src/RolloutEvaluator.ts#L10)'s definition.

```
let configCatClient = configcat.createClient("MY_API_KEY");

let myUser = { identifier: "MY_IDENTIFIER"};

// Get your config value(s):

configCatClient.getValue("isDescEnabled", false, (value) => {
    console.log("isDescEnabled: " + value);
  },
  myUser
);
```