### PR TITLE
change projectConfig's equals to static

### DIFF
--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -43,7 +43,7 @@ export class AutoPollConfigService extends ConfigServiceBase implements IConfigS
             
             const newConfig = await this.refreshLogicBaseAsync(cachedConfig)
             
-            if (!cachedConfig || !cachedConfig.Equals(newConfig)) {
+            if (!cachedConfig || !ProjectConfig.equals(cachedConfig, newConfig)) {
                 
                 this.configChanged();
             }

--- a/src/ProjectConfig.ts
+++ b/src/ProjectConfig.ts
@@ -12,14 +12,22 @@ export class ProjectConfig {
         this.HttpETag = httpETag;
     }
 
-    public Equals(projectConfig: ProjectConfig): boolean {
-        if (!projectConfig) return false;
+    
+    /**
+     * Determines whether the specified ProjectConfig instances are considered equal.
+     */
+    public static equals(projectConfig1: ProjectConfig, projectConfig2: ProjectConfig): boolean {
+        if (!projectConfig1 || !projectConfig2) return false;
 
-        return (this.EnsureStrictEtag(projectConfig.HttpETag) === this.EnsureStrictEtag(this.HttpETag));
+        return (this.ensureStrictEtag(projectConfig1.HttpETag) === this.ensureStrictEtag(projectConfig2.HttpETag));
     }
 
-    private EnsureStrictEtag(etag: string): string {
-        if (etag.length > 2 && etag.substr(0,2).toLocaleUpperCase() === "W/"){
+    private static ensureStrictEtag(etag: string): string {
+        if (!etag) {
+            return etag;
+        }
+
+        if (etag.length > 2 && etag.substr(0,2).toLocaleUpperCase() === "W/") {
             return etag.substring(2);
         }
 

--- a/test/ProjectConfigTests.ts
+++ b/test/ProjectConfigTests.ts
@@ -4,31 +4,65 @@ import { ProjectConfig } from "../src";
 
 describe("ProjectConfig", () => {
   it("Equals - Same etag values - Should equal", () => {
-      const actual: ProjectConfig = new ProjectConfig(1, "{}", "etag")
-      const expected: ProjectConfig = new ProjectConfig(1, "{}", "etag")
+      const actual: ProjectConfig = new ProjectConfig(1, "{}", "etag");
+      const expected: ProjectConfig = new ProjectConfig(1, "{}", "etag");
 
-      assert.isTrue(actual.Equals(expected));
+      assert.isTrue(ProjectConfig.equals(actual, expected));
   });
 
   it("Equals - Different etag values - Should not equal", () => {
-    const actual: ProjectConfig = new ProjectConfig(1, "{}", "etag")
-    const expected: ProjectConfig = new ProjectConfig(1, "{}", "different-etag")
+    const actual: ProjectConfig = new ProjectConfig(1, "{}", "etag");
+    const expected: ProjectConfig = new ProjectConfig(1, "{}", "different-etag");
 
-    assert.isFalse(actual.Equals(expected));
+    assert.isFalse(ProjectConfig.equals(actual, expected));
   });
 
   it("Equals - Actual etag is week - Should equal", () => {
-    const actual: ProjectConfig = new ProjectConfig(1, "{}", "W/\"etag\"")
-    const expected: ProjectConfig = new ProjectConfig(1, "{}", "\"etag\"")
+    const actual: ProjectConfig = new ProjectConfig(1, "{}", "W/\"etag\"");
+    const expected: ProjectConfig = new ProjectConfig(1, "{}", "\"etag\"");
 
-    assert.isTrue(actual.Equals(expected));
+    assert.isTrue(ProjectConfig.equals(actual, expected));
   });
 
   it("Equals - Both tags are weak - Should equal", () => {
-    const actual: ProjectConfig = new ProjectConfig(1, "{}", "W/\"etag\"")
-    const expected: ProjectConfig = new ProjectConfig(1, "{}", "W/\"etag\"")
+    const actual: ProjectConfig = new ProjectConfig(1, "{}", "W/\"etag\"");
+    const expected: ProjectConfig = new ProjectConfig(1, "{}", "W/\"etag\"");
 
-    assert.isTrue(actual.Equals(expected));
+    assert.isTrue(ProjectConfig.equals(actual, expected));
   });
 
+  it("Equals - Actual etag is 'undefined' - Should not equal", () => {
+    const actual: ProjectConfig = new ProjectConfig(1, "{}", undefined);
+    const expected: ProjectConfig = new ProjectConfig(1, "{}", "W/\"etag\"");
+
+    assert.isFalse(ProjectConfig.equals(actual, expected));
+  });
+
+  it("Equals - Both tags are 'undefined' - Should equal", () => {
+    const actual: ProjectConfig = new ProjectConfig(1, "{}", undefined);
+    const expected: ProjectConfig = new ProjectConfig(1, "{}", undefined);
+
+    assert.isTrue(ProjectConfig.equals(actual, expected));
+  });
+
+  it("Equals - Actual etag is null, expected etag is 'undefined'  - Should not equal", () => {
+    const actual: ProjectConfig = new ProjectConfig(1, "{}", null);
+    const expected: ProjectConfig = new ProjectConfig(1, "{}", undefined);
+
+    assert.isFalse(ProjectConfig.equals(actual, expected));
+  });
+
+  it("Equals - Actual is null - Should not equal", () => {
+    const actual: ProjectConfig = null;
+    const expected: ProjectConfig = new ProjectConfig(1, "{}", 'etag');
+
+    assert.isFalse(ProjectConfig.equals(actual, expected));
+  });
+
+  it("Equals - Expected is null - Should not equal", () => {
+    const actual: ProjectConfig = new ProjectConfig(1, "{}", 'etag');
+    const expected: ProjectConfig = null;
+
+    assert.isFalse(ProjectConfig.equals(actual, expected));
+  });
 });


### PR DESCRIPTION
fix TypeError issue
```javascript
configcat.min.js:5 Uncaught (in promise) TypeError: t.Equals is not a function
    at e.<anonymous> (configcat.min.js:5)
    at configcat.min.js:5
    at Object.next (configcat.min.js:5)
    at a (configcat.min.js:5)
```