### PR TITLE
Fix infinite callback loop when autpoll fetch fails with empty cache

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -4,7 +4,7 @@
 
 1. Run `./deploy.sh`
 
-2. Update `common-js` in `js-sdk` and `node-sdk` and re-deploy both packages.
+2. Update `common-js` in `js-sdk` and `node-sdk` and `js-ssr-sdk` and re-deploy both packages.
 
 or
 

--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -43,8 +43,10 @@ export class AutoPollConfigService extends ConfigServiceBase implements IConfigS
             
             const newConfig = await this.refreshLogicBaseAsync(cachedConfig, forceUpdateCache)
             
-            if (!cachedConfig || !ProjectConfig.equals(cachedConfig, newConfig)) {
-                
+            let weDontHaveCachedYetButHaveNew = !cachedConfig && newConfig;
+            let weHaveBothButTheyDiffers = cachedConfig && newConfig && !ProjectConfig.equals(cachedConfig, newConfig);
+
+            if (weDontHaveCachedYetButHaveNew || weHaveBothButTheyDiffers) {                
                 this.configChanged();
             }
 


### PR DESCRIPTION
### Describe the solution you've provided

This PR changes when AutoPoll's `onConfigChange` callback is called. When an unfortunate combination of events occurs like the cache is empty and the first fetch keeps failing, precisely placed `getValue()` calls within an `onConfigChange` can result in a continuous HTTP-BAN-HAMMER towards our CDNs. Also, gives the browser 100% CPU capacity 🧑‍🏭 and a freezing face ⛄. 

Now, we only call the `onConfigChange` when we have a valid HTTP result to compare with the cache.

### Requirement checklist

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
