### PR TITLE
Support Async Caches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "gulp-replace": "^1.0.0",
         "gulp-typescript": "^6.0.0-alpha.1",
         "mocha": "^8.1.3",
-        "moq.ts": "^6.4.0",
+        "moq.ts": "^7.4.1",
         "nyc": "^15.1.0",
         "source-map-support": "^0.5.19",
         "ts-node": "^8.10.2",
@@ -4003,12 +4003,12 @@
       }
     },
     "node_modules/moq.ts": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/moq.ts/-/moq.ts-6.4.0.tgz",
-      "integrity": "sha512-g9siyKOvYGVhfDCl9mpLptch93egRC3yXIbPLssxukOROl368XBB+6M7YjLTkjVRHbKbpJBD6P7od+Ky/0xWIw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/moq.ts/-/moq.ts-7.4.1.tgz",
+      "integrity": "sha512-P97MjGUkkMKQrAHbNScyJvSv3S7pMxnuxd3HgaOrPuoC6okwPqru3ZX8W/mTdU7Ms74622MeeWHqoDaGyYKonw==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.0.0"
+        "tslib": "2.1.0"
       }
     },
     "node_modules/ms": {
@@ -5932,9 +5932,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
       "dev": true
     },
     "node_modules/type": {
@@ -9872,12 +9872,12 @@
       }
     },
     "moq.ts": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/moq.ts/-/moq.ts-6.4.0.tgz",
-      "integrity": "sha512-g9siyKOvYGVhfDCl9mpLptch93egRC3yXIbPLssxukOROl368XBB+6M7YjLTkjVRHbKbpJBD6P7od+Ky/0xWIw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/moq.ts/-/moq.ts-7.4.1.tgz",
+      "integrity": "sha512-P97MjGUkkMKQrAHbNScyJvSv3S7pMxnuxd3HgaOrPuoC6okwPqru3ZX8W/mTdU7Ms74622MeeWHqoDaGyYKonw==",
       "dev": true,
       "requires": {
-        "tslib": "^2.0.0"
+        "tslib": "2.1.0"
       }
     },
     "ms": {
@@ -11448,9 +11448,9 @@
       }
     },
     "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
       "dev": true
     },
     "type": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-replace": "^1.0.0",
     "gulp-typescript": "^6.0.0-alpha.1",
     "mocha": "^8.1.3",
-    "moq.ts": "^6.4.0",
+    "moq.ts": "^7.4.1",
     "nyc": "^15.1.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^8.10.2",

--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -39,7 +39,7 @@ export class AutoPollConfigService extends ConfigServiceBase implements IConfigS
         
         return new Promise(async resolve => {
 
-            let cachedConfig: ProjectConfig = this.baseConfig.cache.get(this.baseConfig.getCacheKey());
+            let cachedConfig: ProjectConfig = await this.baseConfig.cache.get(this.baseConfig.getCacheKey());
             
             const newConfig = await this.refreshLogicBaseAsync(cachedConfig, forceUpdateCache)
             
@@ -66,7 +66,7 @@ export class AutoPollConfigService extends ConfigServiceBase implements IConfigS
 
     private async tryReadFromCache(tries: number): Promise<ProjectConfig> {
         
-        var p: ProjectConfig = this.baseConfig.cache.get(this.baseConfig.getCacheKey());
+        let p: ProjectConfig = await this.baseConfig.cache.get(this.baseConfig.getCacheKey());
 
         if (this.maxInitWaitTimeStamp > new Date().getTime() && !p) {
             

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -22,12 +22,12 @@ export abstract class ConfigServiceBase {
 
         return new Promise(resolve => {
 
-            this.fetchLogic(this.baseConfig, lastProjectConfig, 0, (newConfig) => {
+            this.fetchLogic(this.baseConfig, lastProjectConfig, 0, async (newConfig) => {
 
                 if (newConfig && newConfig.ConfigJSON) {
                     
                     if (forceUpdateCache || !ProjectConfig.equals(newConfig, lastProjectConfig)) {
-                        this.baseConfig.cache.set(this.baseConfig.getCacheKey(), newConfig);
+                        await this.baseConfig.cache.set(this.baseConfig.getCacheKey(), newConfig);
                     }
                     
                     resolve(newConfig);

--- a/src/LazyLoadConfigService.ts
+++ b/src/LazyLoadConfigService.ts
@@ -14,20 +14,20 @@ export class LazyLoadConfigService extends ConfigServiceBase implements IConfigS
         this.cacheTimeToLiveSeconds = config.cacheTimeToLiveSeconds;
     }
 
-    getConfig(): Promise<ProjectConfig> {
+    async getConfig(): Promise<ProjectConfig> {
 
-        let p: ProjectConfig = this.baseConfig.cache.get(this.baseConfig.getCacheKey());
+        let p: ProjectConfig = await this.baseConfig.cache.get(this.baseConfig.getCacheKey());
 
         if (p && p.Timestamp + (this.cacheTimeToLiveSeconds * 1000) > new Date().getTime()) {
-            return new Promise(resolve => resolve(p));
+            return p;
         } else {
             return this.refreshLogicBaseAsync(p);
         }
     }
 
-    refreshConfigAsync(): Promise<ProjectConfig> {
+    async refreshConfigAsync(): Promise<ProjectConfig> {
 
-        let p: ProjectConfig = this.baseConfig.cache.get(this.baseConfig.getCacheKey());
+        let p: ProjectConfig = await this.baseConfig.cache.get(this.baseConfig.getCacheKey());
         return this.refreshLogicBaseAsync(p)
     }
 }

--- a/src/ManualPollService.ts
+++ b/src/ManualPollService.ts
@@ -10,14 +10,16 @@ export class ManualPollService extends ConfigServiceBase implements IConfigServi
         super(configFetcher, config);
     }
 
-    getConfig(): Promise<ProjectConfig> {
+    async getConfig(): Promise<ProjectConfig> {
 
-        return new Promise(resolve => resolve(this.baseConfig.cache.get(this.baseConfig.getCacheKey())));
+        let p: ProjectConfig = await this.baseConfig.cache.get(this.baseConfig.getCacheKey());
+
+        return p;
     }
 
-    refreshConfigAsync(): Promise<ProjectConfig> {
+    async refreshConfigAsync(): Promise<ProjectConfig> {
 
-        let p: ProjectConfig = this.baseConfig.cache.get(this.baseConfig.getCacheKey());
+        let p: ProjectConfig = await this.baseConfig.cache.get(this.baseConfig.getCacheKey());
         return this.refreshLogicBaseAsync(p)
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,9 +89,9 @@ export interface IConfigFetcher {
 }
 
 export interface ICache {
-    set(key: string, config: ProjectConfig): void;
+    set(key: string, config: ProjectConfig): Promise<void> | void;
 
-    get(key: string): ProjectConfig;
+    get(key: string): Promise<ProjectConfig> | ProjectConfig;
 }
 
 export { ProjectConfig } from "./ProjectConfig";


### PR DESCRIPTION
### Describe the purpose of your pull request

It should be possible to use a Cache implementation where the get and set methods are asynchronous. This PR alters all calls to `cache.get` and `cache.set` to be async.

To enable testing these changes it was necessary to bump the dev-dependency `moq.ts` to a version that is neither `@latest` or `@next`. Unfortunately `moq.ts` has not published 7.4.1 as `@latest`, even though it is "latest".

### Requirement checklist (only if applicable)

- [X] I have covered the applied changes with automated tests.
- [X] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [X] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
