### PR TITLE
autopollservice always update cache at first poll

### DIFF
--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -61,13 +61,21 @@ export class AutoPollConfigService extends ConfigServiceBase implements IConfigS
     }
 
     private startRefreshWorker(delay: number) {
+        this.refreshLogic(true).then((_) => {
+            setTimeout(() => this.refreshWorkerLogic(delay), delay);
+        });
+    }
+
+    private refreshWorkerLogic(delay: number) {
+        
+        if (this.disposed) {
+            return;
+        }
+
         this.refreshLogic(false).then((_) => {
-            if (this.disposed) {
-                return;
-            }
             this.timerId = setTimeout(
                 () => {
-                    this.startRefreshWorker(delay);
+                    this.refreshWorkerLogic(delay);
                 },
                 delay);
         });

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -12,7 +12,6 @@ export abstract class ConfigServiceBase {
     protected configFetcher: IConfigFetcher;
     protected baseConfig: OptionsBase;
 
-    private fetchLogicLock = false;
     private fetchLogicCallbacks: ((newProjectConfig: ProjectConfig | null) => void)[] = [];
 
     constructor(configFetcher: IConfigFetcher, baseConfig: OptionsBase) {

--- a/test/ConfigServiceBaseTests.ts
+++ b/test/ConfigServiceBaseTests.ts
@@ -7,6 +7,7 @@ import { Mock, It, Times, EqualMatchingInjectorConfig, ResolvedPromiseFactory, R
 import { ReturnsAsyncPresetFactory, ThrowsAsyncPresetFactory, MimicsResolvedAsyncPresetFactory, MimicsRejectedAsyncPresetFactory, RootMockProvider, Presets } from "moq.ts/internal";
 import { LazyLoadConfigService } from "../src/LazyLoadConfigService";
 import { assert } from "chai";
+import { InMemoryCache } from "../src/Cache";
 
 describe("ConfigServiceBaseTests", () => {
 
@@ -25,7 +26,7 @@ describe("ConfigServiceBaseTests", () => {
         ])
     };
 
-    it("AutoPollConfigService - backgroundworker only - config doesn't exits in the cache - invokes 'cache.set' operation only once", async () => {
+    it("AutoPollConfigService - backgroundworker only - config doesn't exist in the cache - invokes 'cache.set' operation only once", async () => {
 
         // Arrange
 
@@ -96,18 +97,22 @@ describe("ConfigServiceBaseTests", () => {
         cacheMock.verify(v => v.set(It.IsAny<string>(), pc), Times.Exactly(2));        
     });
 
-    it("AutoPollConfigService - ProjectConfig is cached and fetch returns same value - should never invokes 'cache.set' operation", async () => {
+    it("AutoPollConfigService - ProjectConfig is cached and fetch returns same value - should invoke the 'cache.set' operation only once (at first)", async () => {
 
         // Arrange
 
+        const projectConfigOld: ProjectConfig = CreateProjectConfig();
+        const projectConfigNew: ProjectConfig = CreateProjectConfig();
+        projectConfigNew.Timestamp = new Date().getTime();
+
         const fetcherMock = new Mock<IConfigFetcher>()
         .setup(m => m.fetchLogic(It.IsAny<OptionsBase>(), It.IsAny<ProjectConfig>(), It.IsAny<any>()))
-        .callback(({args: [a1, a2, cb]}) => cb(CreateProjectConfig()));
+        .callback(({args: [a1, a2, cb]}) => cb(projectConfigNew));
 
         const cacheMock = new Mock<ICache>()
         .setup(m => m.get(It.IsAny<string>()))
         .returns(CreateProjectConfig())
-        .setup(m => m.set(It.IsAny<string>(), CreateProjectConfig()))
+        .setup(m => m.set(It.IsAny<string>(), projectConfigOld))
         .returns();
 
         // Act
@@ -123,39 +128,150 @@ describe("ConfigServiceBaseTests", () => {
 
         // Assert
 
-        cacheMock.verify(v => v.set(It.IsAny<string>(), It.IsAny<ProjectConfig>()), Times.Never());        
+        cacheMock.verify(v => v.set(
+            It.IsAny<string>(),
+            It.Is<ProjectConfig>(actual => actual.Timestamp == projectConfigNew.Timestamp)),
+        Times.Once());     
     });
 
-    it("AutoPollConfigService - Async cache is supported", async () => {
+    it("AutoPollConfigService - Cached config is the same as ProjectConfig but older than the polling time - Should wait until the cache is updated with the new timestamp", async () => {
         // Arrange
+
+        const pollInterval: number = 10;
+
+        const projectConfigNew: ProjectConfig = CreateProjectConfig();
+
+        const projectConfigOld: ProjectConfig = CreateProjectConfig();
+
+        const time: number = new Date().getTime();
+
+        projectConfigNew.Timestamp = time;  
+
+        projectConfigOld.Timestamp = time - (pollInterval * 1001);
+
+        const cache: ICache = new InMemoryCache();
+
+        const options: AutoPollOptions = new AutoPollOptions(
+            "APIKEY",
+            {
+                pollIntervalSeconds: pollInterval,
+                maxInitWaitTimeSeconds: 100
+            },
+            cache);
+        
+        await cache.set(options.getCacheKey(), projectConfigOld);
 
         const fetcherMock = new Mock<IConfigFetcher>()
         .setup(m => m.fetchLogic(It.IsAny<OptionsBase>(), It.IsAny<ProjectConfig>(), It.IsAny<any>()))
-        .callback(({args: [a1, a2, cb]}) => cb(CreateProjectConfig()));
-
-        const cacheMock = new Mock<ICache>(asyncInjectorServiceConfig)
-        .setup(async m => m.get(It.IsAny<string>()))
-        .returnsAsync(CreateProjectConfig())
-        .setup(async m => m.set(It.IsAny<string>(), CreateProjectConfig()))
-        .returnsAsync();
+        .callback(({args: [_, __, cb]}) => {
+            setTimeout(() => cb(projectConfigNew), 100)
+        });
 
         // Act
 
         const service : AutoPollConfigService = new AutoPollConfigService(
             fetcherMock.object(),
-            new AutoPollOptions(
-                "APIKEY",
-                { pollIntervalSeconds: 1 },
-                cacheMock.object()));
+            options);
 
-        await new Promise(resolve => setTimeout(resolve, 3000));
+        const actualProjectConfig: ProjectConfig | null = await service.getConfig();
 
         // Assert
 
-        cacheMock.verify(v => v.set(It.IsAny<string>(), It.IsAny<ProjectConfig>()), Times.Never());
+        assert.isNotNull(actualProjectConfig);
+        assert.equal(actualProjectConfig?.Timestamp, projectConfigNew.Timestamp);
     });
 
-    it("LazyLoadConfigService - ProjectConfig is older in the cache - should fetch a new config and put into cache", async () => {
+    it("AutoPollConfigService - Cached config is the same as ProjectConfig but older than the polling time - Should return cached item", async () => {
+        // Arrange
+
+        const pollInterval: number = 10;
+
+        const projectConfigNew: ProjectConfig = CreateProjectConfig();
+
+        const projectConfigOld: ProjectConfig = CreateProjectConfig();
+
+        const time: number = new Date().getTime();
+
+        projectConfigNew.Timestamp = time;  
+
+        projectConfigOld.Timestamp = time - (pollInterval * 999);
+
+        const cache: ICache = new InMemoryCache();
+
+        const options: AutoPollOptions = new AutoPollOptions(
+            "APIKEY",
+            {
+                pollIntervalSeconds: pollInterval,
+                maxInitWaitTimeSeconds: 100
+            },
+            cache);
+        
+        await cache.set(options.getCacheKey(), projectConfigOld);
+
+        const fetcherMock = new Mock<IConfigFetcher>()
+        .setup(m => m.fetchLogic(It.IsAny<OptionsBase>(), It.IsAny<ProjectConfig>(), It.IsAny<any>()))
+        .callback(({args: [_, __, cb]}) => {
+            setTimeout(() => cb(projectConfigNew), 100)
+        });
+
+        // Act
+
+        const service : AutoPollConfigService = new AutoPollConfigService(
+            fetcherMock.object(),
+            options);
+
+        const actualProjectConfig: ProjectConfig | null = await service.getConfig();
+
+        // Assert
+
+        assert.isNotNull(actualProjectConfig);
+        assert.equal(actualProjectConfig?.Timestamp, projectConfigOld.Timestamp);
+    });
+
+    it("AutoPollConfigService - ProjectConfigs are same but cache stores older config than poll interval and fetch operation is longer than maxInitWaitTimeSeconds - Should return cached item", async () => {
+        // Arrange
+
+        const pollInterval: number = 10;
+
+        const projectConfigOld: ProjectConfig = CreateProjectConfig();
+
+        const time: number = new Date().getTime(); 
+
+        projectConfigOld.Timestamp = time - (pollInterval * 3000);
+
+        const cache: ICache = new InMemoryCache();
+
+        const options: AutoPollOptions = new AutoPollOptions(
+            "APIKEY",
+            {
+                pollIntervalSeconds: pollInterval,
+                maxInitWaitTimeSeconds: 1
+            },
+            cache);
+        
+        await cache.set(options.getCacheKey(), projectConfigOld);
+
+        const fetcherMock = new Mock<IConfigFetcher>()
+        .setup(m => m.fetchLogic(It.IsAny<OptionsBase>(), It.IsAny<ProjectConfig>(), It.IsAny<any>()))
+        .callback(({args: [_, __, cb]}) => {
+            setTimeout(() => cb(null), 2000)
+        });
+
+        // Act
+
+        const service : AutoPollConfigService = new AutoPollConfigService(
+            fetcherMock.object(),
+            options);
+
+        const actualProjectConfig: ProjectConfig | null = await service.getConfig();
+
+        // Assert
+
+        assert.isNotNull(actualProjectConfig);
+        assert.equal(actualProjectConfig?.Timestamp, projectConfigOld.Timestamp);
+    });
+
+    it("LazyLoadConfigService - ProjectConfig is different in the cache - should fetch a new config and put into cache", async () => {
 
         // Arrange
 


### PR DESCRIPTION
### Describe the purpose of your pull request

AutoPollConfigService will always update the cache at the first poll with the latest `TimeStamp` value even if it does not change. The `GetConfig` method will only block while the fetch logic returns the result or for the time specified in the `maxInitWaitTimeSeconds` parameter (default: 5000 ms).

### Related issues (only if applicable)

https://github.com/configcat/common-js/issues/43

### Requirement checklist (only if applicable)

- [X] I have covered the applied changes with automated tests.
- [X] I have executed the full automated test set against my changes.
- [X] I have validated my changes against all supported platform versions.
- [X] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
