### PR TITLE
Move sdk version to the fetch url as query parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-common",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-common",
-      "version": "5.3.0",
+      "version": "6.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-common",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "ConfigCat is a configuration as a service that lets you manage your features and configurations without actually deploying new code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -108,7 +108,7 @@ export abstract class OptionsBase implements IOptions {
     }
 
     getUrl(): string {
-        return this.baseUrl + "/configuration-files/" + this.apiKey + "/" + this.configFileName + ".json";
+        return this.baseUrl + "/configuration-files/" + this.apiKey + "/" + this.configFileName + ".json" + "?sdk=" + this.clientVersion;
     }
 
     getCacheKey(): string {

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -26,7 +26,7 @@ describe("Options", () => {
 
     assert.equal("APIKEY", options.apiKey);
     assert.equal(30000, options.requestTimeoutMs);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json", options.getUrl());
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/m-1.0.0", options.getUrl());
   });
 
   it("ManualPollOptions initialization With parameters works", () => {
@@ -45,7 +45,7 @@ describe("Options", () => {
     assert.equal(fakeLogger, options.logger);
     assert.equal("APIKEY", options.apiKey);
     assert.equal(10, options.requestTimeoutMs);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json", options.getUrl());
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/m-1.0.0", options.getUrl());
     assert.equal("http://fake-proxy.com:8080", options.proxy);
   });
 
@@ -54,8 +54,8 @@ describe("Options", () => {
     let options: ManualPollOptions = new ManualPollOptions("APIKEY", "common", "1.0.0", { baseUrl: "https://mycdn.example.org" }, null);
 
     assert.isDefined(options);
-    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v5.json", options.getUrl());
-    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json", options.getUrl());
+    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v5.json?sdk=common/m-1.0.0", options.getUrl());
+    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/m-1.0.0", options.getUrl());
   });
 
   it("AutoPollOptions initialization With -1 requestTimeoutMs ShouldThrowError", () => {
@@ -69,7 +69,7 @@ describe("Options", () => {
     assert.isDefined(options);
     assert.isTrue(options.logger instanceof ConfigCatConsoleLogger);
     assert.equal("APIKEY", options.apiKey);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json", options.getUrl());
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/a-1.0.0", options.getUrl());
     assert.equal(60, options.pollIntervalSeconds);
     assert.equal(30000, options.requestTimeoutMs);
     assert.isDefined(options.cache);
@@ -93,7 +93,7 @@ describe("Options", () => {
     assert.isDefined(options);
     assert.equal(fakeLogger, options.logger);
     assert.equal("APIKEY", options.apiKey);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json", options.getUrl());
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/a-1.0.0", options.getUrl());
     assert.equal(59, options.pollIntervalSeconds);
     assert.equal(20, options.requestTimeoutMs);
     assert.equal(configChanged, options.configChanged);
@@ -125,8 +125,8 @@ describe("Options", () => {
     let options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { baseUrl: "https://mycdn.example.org" }, null);
 
     assert.isDefined(options);
-    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v5.json", options.getUrl());
-    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json", options.getUrl());
+    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v5.json?sdk=common/a-1.0.0", options.getUrl());
+    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/a-1.0.0", options.getUrl());
   });
 
   it("AutoPollOptions initialization With -1 'maxInitWaitTimeSeconds' ShouldThrowError", () => {
@@ -155,7 +155,7 @@ describe("Options", () => {
     let options: LazyLoadOptions = new LazyLoadOptions("APIKEY", "common", "1.0.0", null, null);
     assert.isDefined(options);
     assert.equal("APIKEY", options.apiKey);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json", options.getUrl());
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/l-1.0.0", options.getUrl());
     assert.equal(60, options.cacheTimeToLiveSeconds);
     assert.equal(30000, options.requestTimeoutMs);
   });
@@ -175,7 +175,7 @@ describe("Options", () => {
     assert.isDefined(options);
     assert.equal(fakeLogger, options.logger);
     assert.equal("APIKEY", options.apiKey);
-    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json", options.getUrl());
+    assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/l-1.0.0", options.getUrl());
     assert.equal(59, options.cacheTimeToLiveSeconds);
     assert.equal(20, options.requestTimeoutMs);
     assert.equal("http://fake-proxy.com:8080", options.proxy);
@@ -205,8 +205,8 @@ describe("Options", () => {
     let options: LazyLoadOptions = new LazyLoadOptions("APIKEY", "common", "1.0.0", { baseUrl: "https://mycdn.example.org" }, null);
 
     assert.isDefined(options);
-    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v5.json", options.getUrl());
-    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json", options.getUrl());
+    assert.equal("https://mycdn.example.org/configuration-files/APIKEY/config_v5.json?sdk=common/l-1.0.0", options.getUrl());
+    assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/l-1.0.0", options.getUrl());
   });
 
   it("Options initialization With 'defaultCache' Should set option cache to passed instance", () => {

--- a/test/DataGovernanceTests.ts
+++ b/test/DataGovernanceTests.ts
@@ -297,6 +297,6 @@ export class FakeConfigServiceBase extends ConfigServiceBase {
     }
 
     private getUrl(baseUrl: string) {
-        return baseUrl + "/configuration-files/API_KEY/config_v5.json";
+        return baseUrl + "/configuration-files/API_KEY/config_v5.json?sdk=" + this.baseConfig.clientVersion;
     }
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR moves the SDK version to the fetch url as a query parameter. Descendant SDKs will send the SDK version as a query parameter instead of the dedicated `X-ConfigCat-UserAgent` header.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
