### PR TITLE
LazyLoad and AutoPoll refresh logic improvements

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -8,7 +8,7 @@ export class InMemoryCache implements ICache {
         this.cache[key] = config;
     }
 
-    get(key: string): ProjectConfig {
-        return this.cache[key];
+    get(key: string): ProjectConfig | null {
+        return this.cache[key] ?? null;
     }
 }

--- a/src/ManualPollService.ts
+++ b/src/ManualPollService.ts
@@ -3,22 +3,21 @@ import { ManualPollOptions } from "./ConfigCatClientOptions";
 import { IConfigFetcher } from "./index";
 import { ProjectConfig } from "./ProjectConfig";
 
-export class ManualPollService extends ConfigServiceBase implements IConfigService {
+export class ManualPollService extends ConfigServiceBase<ManualPollOptions> implements IConfigService {
 
-    public constructor(configFetcher: IConfigFetcher, config: ManualPollOptions) {
+    constructor(configFetcher: IConfigFetcher, options: ManualPollOptions) {
 
-        super(configFetcher, config);
+        super(configFetcher, options);
     }
 
     async getConfig(): Promise<ProjectConfig | null> {
 
-        this.baseConfig.logger.debug("ManualPollService.getConfig() called.");
-        return await this.baseConfig.cache.get(this.baseConfig.getCacheKey());
+        this.options.logger.debug("ManualPollService.getConfig() called.");
+        return await this.options.cache.get(this.options.getCacheKey());
     }
 
     async refreshConfigAsync(): Promise<ProjectConfig | null> {
-        this.baseConfig.logger.debug("ManualPollService.refreshConfigAsync() called.");
-        let p = await this.baseConfig.cache.get(this.baseConfig.getCacheKey());
-        return this.refreshLogicBaseAsync(p)
+        this.options.logger.debug("ManualPollService.refreshConfigAsync() called.");
+        return super.refreshConfigAsync();
     }
 }

--- a/src/ProjectConfig.ts
+++ b/src/ProjectConfig.ts
@@ -3,12 +3,12 @@ export class ProjectConfig {
     HttpETag?: string;
     /** ConfigCat config */
     ConfigJSON: any;
-    /** Timestamp in milliseconds */
+    /** Timestamp of last successful download (regardless of whether the config has changed or not) in milliseconds */
     Timestamp: number;
 
-    constructor(timeStamp: number, jsonConfig: string, httpETag?: string) {
+    constructor(timeStamp: number, jsonConfig: string | object, httpETag?: string) {
         this.Timestamp = timeStamp;
-        this.ConfigJSON = JSON.parse(jsonConfig);
+        this.ConfigJSON = typeof jsonConfig === "string" ? JSON.parse(jsonConfig) : jsonConfig;
         this.HttpETag = httpETag;
     }
 
@@ -16,9 +16,8 @@ export class ProjectConfig {
      * Determines whether the specified ProjectConfig instances are considered equal.
      */
     public static equals(projectConfig1: ProjectConfig | null, projectConfig2: ProjectConfig | null): boolean {
-        if (!projectConfig1 || !projectConfig2) return false;
-
-        return this.compareEtags(projectConfig1.HttpETag, projectConfig2.HttpETag);
+        // If both configs are null, we consider them equal.
+        return projectConfig1 ? !!projectConfig2 && this.compareEtags(projectConfig1.HttpETag, projectConfig2.HttpETag) : !projectConfig2;
     }
 
     public static compareEtags(etag1?: string, etag2?: string): boolean {
@@ -35,6 +34,10 @@ export class ProjectConfig {
         }
 
         return etag;
+    }
+
+    public static isExpired(projectConfig: ProjectConfig | null, expirationMs: number): boolean {
+        return !projectConfig || projectConfig.Timestamp + expirationMs < new Date().getTime();
     }
 }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2,6 +2,13 @@ import { ConfigFile, Setting } from "./ProjectConfig";
 
 export const isUndefined = (comp: any) => comp === void 0;
 
+export function delay(delayMs: number, obtainCancel?: (cancel: () => void) => void): Promise<void> {
+    let timerId: ReturnType<typeof setTimeout>;
+    const promise = new Promise<void>(resolve => timerId = setTimeout(resolve, delayMs));
+    obtainCancel?.(() => clearTimeout(timerId));
+    return promise;
+};
+
 export function getSettingsFromConfig(json: any): { [name: string]: Setting } {
     if (!json) {
         return {};

--- a/test/ConfigCatClientCacheTests.ts
+++ b/test/ConfigCatClientCacheTests.ts
@@ -3,9 +3,9 @@ import { assert } from "chai";
 import { ConfigCatClient } from "../src/ConfigCatClient";
 import { ConfigCatClientCache } from "../src/ConfigCatClient";
 import { AutoPollOptions, ManualPollOptions } from "../src/ConfigCatClientOptions";
-import { FakeConfigCatKernel, FakeConfigFetcher } from "./ConfigCatClientTests";
 import { isWeakRefAvailable, setupPolyfills } from "../src/Polyfills";
 import { allowEventLoop } from "./helpers/utils";
+import { FakeConfigCatKernel, FakeConfigFetcher } from "./helpers/fakes";
 import "./helpers/ConfigCatClientCacheExtensions";
 
 describe("ConfigCatClientCache", () => {

--- a/test/DataGovernanceTests.ts
+++ b/test/DataGovernanceTests.ts
@@ -262,13 +262,13 @@ export class FakeOptions extends OptionsBase {
     }
 }
 
-export class FakeConfigServiceBase extends ConfigServiceBase {
+export class FakeConfigServiceBase extends ConfigServiceBase<FakeOptions> {
     constructor(dataGovernance?: DataGovernance, baseUrl?: string) {
         super(new FakeConfigFetcher(), new FakeOptions(baseUrl, dataGovernance));
     }
 
     refreshLogicAsync(): Promise<ProjectConfig | null> {
-        return this.refreshLogicBaseAsync(null);
+        return this.refreshConfigCoreAsync(null);
     }
 
     prepareResponse(baseUrl: string, jsonBaseUrl: string, jsonRedirect: number, jsonFeatureFlags: any) {
@@ -297,6 +297,6 @@ export class FakeConfigServiceBase extends ConfigServiceBase {
     }
 
     private getUrl(baseUrl: string) {
-        return baseUrl + "/configuration-files/API_KEY/config_v5.json?sdk=" + this.baseConfig.clientVersion;
+        return baseUrl + "/configuration-files/API_KEY/config_v5.json?sdk=" + this.options.clientVersion;
     }
 }

--- a/test/DefaultUserTests.ts
+++ b/test/DefaultUserTests.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import "mocha";
 import { IConfigCatClient, User } from "../src";
-import { FakeConfigCatKernel, FakeConfigFetcherWithRules } from "./ConfigCatClientTests";
+import { FakeConfigCatKernel, FakeConfigFetcherWithRules } from "./helpers/fakes";
 import * as configcatClient from "../src/index";
 import { assert } from "chai";
 

--- a/test/IndexTests.ts
+++ b/test/IndexTests.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 import "mocha";
 import * as configcatClient from "../src/index";
 import { IConfigCatClient } from "../src/ConfigCatClient";
-import { FakeConfigFetcher, FakeConfigCatKernel } from "./ConfigCatClientTests";
+import { FakeConfigCatKernel, FakeConfigFetcher } from "./helpers/fakes";
 import { InMemoryCache } from "../src/Cache";
 
 describe("ConfigCatClient index (main)", () => {

--- a/test/MatrixTests.ts
+++ b/test/MatrixTests.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import { User } from "../src/RolloutEvaluator";
 import { ConfigCatConsoleLogger } from "../src/ConfigCatLogger";
 import { LogLevel, createClientWithManualPoll } from "../src";
-import { FakeConfigCatKernel, FakeConfigFetcherBase } from "./ConfigCatClientTests";
+import { FakeConfigCatKernel, FakeConfigFetcherBase } from "./helpers/fakes";
 
 describe("MatrixTests", () => {
 

--- a/test/OverrideTests.ts
+++ b/test/OverrideTests.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import { IConfigCatClient } from "../src";
 import { AutoPollOptions } from "../src/ConfigCatClientOptions";
-import { FakeConfigCatKernel, FakeConfigFetcherBase } from "./ConfigCatClientTests";
+import { FakeConfigCatKernel, FakeConfigFetcherBase } from "./helpers/fakes";
 import { ConfigCatClient } from "../src/ConfigCatClient";
 import "mocha";
 import { MapOverrideDataSource, OverrideBehaviour } from "../src/FlagOverrides";

--- a/test/ProjectConfigTests.ts
+++ b/test/ProjectConfigTests.ts
@@ -59,6 +59,13 @@ describe("ProjectConfig", () => {
     assert.isFalse(ProjectConfig.equals(actual, expected));
   });
 
+  it("Equals - Both actual and expected are null - Should equal", () => {
+    const actual: ProjectConfig | null = null;
+    const expected: ProjectConfig | null = null;
+
+    assert.isTrue(ProjectConfig.equals(actual, expected));
+  });
+
   it("Equals - Case-sensitive equals - Should not equal", () => {
     const actual: ProjectConfig = new ProjectConfig(1, "{}", 'etag');
     const expected: ProjectConfig = new ProjectConfig(1, "{}", 'ETAG');

--- a/test/VariationIdMatrixTests.ts
+++ b/test/VariationIdMatrixTests.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 import "mocha";
 import { User } from "../src/RolloutEvaluator";
 import * as fs from "fs";
-import { FakeConfigFetcherBase, FakeConfigCatKernel } from "./ConfigCatClientTests";
+import { FakeConfigFetcherBase, FakeConfigCatKernel } from "./helpers/fakes";
 import { AutoPollOptions } from "../src/ConfigCatClientOptions";
 import { IConfigCatClient, ConfigCatClient } from "../src/ConfigCatClient";
 

--- a/test/VariationIdTests.ts
+++ b/test/VariationIdTests.ts
@@ -2,8 +2,7 @@ import { ConfigCatClient, IConfigCatClient } from "../src/ConfigCatClient";
 import { assert } from "chai";
 import "mocha";
 import { AutoPollOptions } from "../src/ConfigCatClientOptions";
-import { InMemoryCache } from "../src/Cache";
-import { FakeConfigCatKernel, FakeConfigFetcherWithTwoKeys, FakeConfigFetcherWithTwoKeysAndRules, FakeConfigFetcherWithNullNewConfig } from "./ConfigCatClientTests";
+import { FakeConfigCatKernel, FakeConfigFetcherWithTwoKeys, FakeConfigFetcherWithTwoKeysAndRules, FakeConfigFetcherWithNullNewConfig } from "./helpers/fakes";
 
 describe("ConfigCatClient", () => {
     it("getVariationId() works", (done) => {

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -1,9 +1,9 @@
-import { IConfigCatLogger, LogLevel } from "../../src";
+import { FetchResult, ICache, IConfigCatKernel, IConfigCatLogger, IConfigFetcher, LogLevel, OptionsBase, ProjectConfig } from "../../src";
 
 export class FakeLogger implements IConfigCatLogger {
     public messages: [LogLevel, string][] = [];
 
-    constructor (public level = LogLevel.Info) { }
+    constructor(public level = LogLevel.Info) { }
 
     reset() { this.messages.splice(0); }
 
@@ -37,5 +37,97 @@ export class FakeLogger implements IConfigCatLogger {
         if (this.isLogLevelEnabled(LogLevel.Error)) {
             this.messages.push([LogLevel.Error, message]);
         }
+    }
+}
+
+export class FakeConfigCatKernel implements IConfigCatKernel {
+    cache?: ICache;
+    configFetcher!: IConfigFetcher;
+    sdkType = "common";
+    sdkVersion = "1.0.0";
+}
+
+export class FakeCache implements ICache {
+    cached: ProjectConfig | null;
+    constructor(cached: ProjectConfig | null = null) {
+        this.cached = cached;
+    }
+    set(key: string, config: ProjectConfig): Promise<void> | void {
+        this.cached = config;
+    }
+    get(key: string): Promise<ProjectConfig | null> | ProjectConfig | null {
+        return this.cached;
+    }
+}
+
+export class FakeConfigFetcherBase implements IConfigFetcher {
+    calledTimes = 0;
+
+    constructor(private config: string | null, private callbackDelay: number = 0) {
+    }
+
+    fetchLogic(options: OptionsBase, lastEtag: string, callback: (result: FetchResult) => void): void {
+        if (callback) {
+            setTimeout(() => {
+                this.calledTimes++;
+                callback(this.config === null ? FetchResult.error() : FetchResult.success(this.config, this.getEtag()));
+            }, this.callbackDelay);
+        }
+    }
+
+    protected getEtag(): string {
+        return "etag";
+    }
+}
+
+
+export class FakeConfigFetcher extends FakeConfigFetcherBase {
+    constructor(private callbackDelayInMilliseconds: number = 0) {
+        super("{\"f\": { \"debug\": { \"v\": true, \"i\": \"abcdefgh\", \"t\": 0, \"p\": [], \"r\": [] } } }", callbackDelayInMilliseconds);
+    }
+}
+
+export class FakeConfigFetcherWithTwoKeys extends FakeConfigFetcherBase {
+    constructor() {
+        super("{\"f\": { \"debug\": { \"v\": true, \"i\": \"abcdefgh\", \"t\": 0, \"p\": [], \"r\": [] }, \"debug2\": { \"v\": true, \"i\": \"12345678\", \"t\": 0, \"p\": [], \"r\": [] } } }");
+    }
+}
+
+export class FakeConfigFetcherWithTwoCaseSensitiveKeys extends FakeConfigFetcherBase {
+    constructor() {
+        super("{\"f\": { \"debug\": { \"v\": \"debug\", \"i\": \"abcdefgh\", \"t\": 1, \"p\": [], \"r\": [{ \"o\":0, \"a\":\"CUSTOM\", \"t\":0, \"c\":\"c\", \"v\":\"UPPER-VALUE\", \"i\":\"6ada5ff2\"}, { \"o\":1, \"a\":\"custom\", \"t\":0, \"c\":\"c\", \"v\":\"lower-value\", \"i\":\"6ada5ff2\"}] }, \"DEBUG\": { \"v\": \"DEBUG\", \"i\": \"12345678\", \"t\": 1, \"p\": [], \"r\": [] } } }");
+    }
+}
+
+export class FakeConfigFetcherWithTwoKeysAndRules extends FakeConfigFetcherBase {
+    constructor() {
+        super("{\"f\": { \"debug\": { \"v\": \"def\", \"i\": \"abcdefgh\", \"t\": 1, \"p\": [], \"r\": [{ \"o\":0, \"a\":\"a\", \"t\":1, \"c\":\"abcd\", \"v\":\"value\", \"i\":\"6ada5ff2\"}] }, \"debug2\": { \"v\": \"def\", \"i\": \"12345678\", \"t\": 1, \"p\": [{\"o\":0, \"v\":\"value1\", \"p\":50, \"i\":\"d227b334\" }, { \"o\":1, \"v\":\"value2\", \"p\":50, \"i\":\"622f5d07\" }], \"r\": [] } } }");
+    }
+}
+
+export class FakeConfigFetcherWithRules extends FakeConfigFetcherBase {
+    constructor() {
+        super("{\"f\": { \"debug\": { \"v\": \"defaultValue\", \"i\": \"defaultVariationId\", \"t\": 0, \"p\": [], \"r\": [{ \"o\":0, \"a\":\"eyeColor\", \"t\":0, \"c\":\"red\", \"v\":\"redValue\", \"i\":\"redVariationId\"}, { \"o\":1, \"a\":\"eyeColor\", \"t\":0, \"c\":\"blue\", \"v\":\"blueValue\", \"i\":\"blueVariationId\"}] } } }");
+    }
+}
+export class FakeConfigFetcherWithNullNewConfig extends FakeConfigFetcherBase {
+    constructor() {
+        super(null);
+    }
+}
+
+export class FakeConfigFetcherWithAlwaysVariableEtag extends FakeConfigFetcherBase {
+    constructor() {
+        super("{ \"f\": { \"debug\": { \"v\": true, \"i\": \"abcdefgh\", \"t\": 0, \"p\": [], \"r\": [] } }}");
+    }
+
+    getEtag(): string {
+        return Math.random().toString();
+    }
+}
+
+export class FakeConfigFetcherWithPercantageRules extends FakeConfigFetcherBase {
+    constructor() {
+        super("{\"f\":{\"string25Cat25Dog25Falcon25Horse\":{\"v\":\"Chicken\",\"t\":1,\"p\":[{\"o\":0,\"v\":\"Cat\",\"p\":25},{\"o\":1,\"v\":\"Dog\",\"p\":25},{\"o\":2,\"v\":\"Falcon\",\"p\":25},{\"o\":3,\"v\":\"Horse\",\"p\":25}],\"r\":[]}}}");
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "strict": true,
     "target": "ES2020",
     "lib": [
-      "ES2015",
+      "ES2015", // APIs used: Promise (.race)
       "DOM", // APIs used: setTimeout, clearTimeout
       "ES2017.Object", // APIs used: Object.values, Object.entries
       "ES2019.Object", // APIs used: Object.fromEntries (polyfilled)


### PR DESCRIPTION
### Describe the purpose of your pull request

* Improves refresh logic of `AutoPollConfigService` and `LazyLoadConfigService` to take the cache download time into account to fetch the config only if cached config is unavailable or stale.
* Also does some cleanup around `*ConfigService` classes.

Breaking changes:
* Slightly changes the behavior of `ProjectConfig.Timestamp` (only updated when download succeeds, regardless of whether the config has changed or not). ~Note: **this may need further discussion** as it slightly differs from e.g. the .NET SDK behavior, which updates timestamp not only when receiving status code 200 or 304 but also on any successful communication with the CDN servers, regardless of the returned status code. In case we want to fully align the behavior across these SDKs, we need to change the implementations of `IConfigFetcher` in the JS SDKs because they don't provide the necessary information currently.~ This is addressed by https://github.com/configcat/common-js/pull/66

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
