### PR TITLE
Offline mode feature

### DIFF
--- a/samples/deno-sandbox/import_map.json
+++ b/samples/deno-sandbox/import_map.json
@@ -12,7 +12,7 @@
     "../../src/ConfigServiceBase": "../../src/ConfigServiceBase.ts",
     "../../src/FlagOverrides": "../../src/FlagOverrides.ts",
     "../../src/LazyLoadConfigService": "../../src/LazyLoadConfigService.ts",
-    "../../src/ManualPollService": "../../src/ManualPollService.ts",
+    "../../src/ManualPollConfigService": "../../src/ManualPollConfigService.ts",
     "../../src/Polyfills": "../../src/Polyfills.ts",
     "../../src/ProjectConfig": "../../src/ProjectConfig.ts",
     "../../src/RolloutEvaluator": "../../src/RolloutEvaluator.ts",

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -3,7 +3,7 @@ import { AutoPollOptions, ManualPollOptions, LazyLoadOptions, OptionsBase, Confi
 import { IConfigService } from "./ConfigServiceBase";
 import { AutoPollConfigService } from "./AutoPollConfigService";
 import { LazyLoadConfigService } from "./LazyLoadConfigService";
-import { ManualPollService } from "./ManualPollService";
+import { ManualPollConfigService } from "./ManualPollConfigService";
 import { User, IRolloutEvaluator, RolloutEvaluator } from "./RolloutEvaluator";
 import { Setting, RolloutRule, RolloutPercentageItem, ConfigFile } from "./ProjectConfig";
 import { OverrideBehaviour } from "./FlagOverrides";
@@ -186,7 +186,7 @@ export class ConfigCatClient implements IConfigCatClient {
         if (options.flagOverrides?.behaviour != OverrideBehaviour.LocalOnly) {
             const configServiceClass =
                 options instanceof AutoPollOptions ? AutoPollConfigService :
-                options instanceof ManualPollOptions ? ManualPollService :
+                options instanceof ManualPollOptions ? ManualPollConfigService :
                 options instanceof LazyLoadOptions ? LazyLoadConfigService :
                 (() => { throw new Error("Invalid 'options' value"); })();
 

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -31,6 +31,10 @@ export interface IOptions {
      * ConfigCatClient.getValue, ConfigCatClient.getValueAsync, getVariationId, getVariationIdAsync, getAllValues, getAllValuesAsync, etc. methods.
      */
     defaultUser?: User | null;
+    /**
+     * Indicates whether the client should be initialized to offline mode or not. Defaults to false.
+     */
+    offline?: boolean | null;
 }
 
 export abstract class OptionsBase implements IOptions {
@@ -57,7 +61,9 @@ export abstract class OptionsBase implements IOptions {
 
     public flagOverrides?: FlagOverrides;
 
-    public defaultUser?: User | null;
+    public defaultUser?: User;
+
+    public offline: boolean = false;
 
     constructor(apiKey: string, clientVersion: string, options?: IOptions | null, defaultCache?: ICache | null) {
         if (!apiKey) {
@@ -114,6 +120,10 @@ export abstract class OptionsBase implements IOptions {
 
             if (options.defaultUser) {
                 this.defaultUser = options.defaultUser;
+            }
+
+            if (options.offline) {
+                this.offline = options.offline;
             }
         }
     }

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -6,11 +6,26 @@ export interface IConfigService {
     getConfig(): Promise<ProjectConfig | null>;
 
     refreshConfigAsync(): Promise<ProjectConfig | null>;
+
+    get isOffline(): boolean;
+
+    setOnline(): void;
+
+    setOffline(): void;
+
+    dispose(): void;
+}
+
+enum ConfigServiceStatus {
+    Online,
+    Offline,
+    Disposed,
 }
 
 export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     protected configFetcher: IConfigFetcher;
     protected options: TOptions;
+    private status: ConfigServiceStatus;
 
     private fetchLogicCallbacks: ((result: FetchResult) => void)[] = [];
 
@@ -18,16 +33,29 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
         this.configFetcher = configFetcher;
         this.options = options;
+        this.status = options.offline ? ConfigServiceStatus.Offline : ConfigServiceStatus.Online;
     }
+
+    dispose(): void {
+        this.status = ConfigServiceStatus.Disposed;
+    }
+
+    protected get disposed() { return this.status === ConfigServiceStatus.Disposed; }
 
     async refreshConfigAsync(): Promise<ProjectConfig | null> {
         const latestConfig = await this.options.cache.get(this.options.getCacheKey());
-        return await this.refreshConfigCoreAsync(latestConfig);
+        if (!this.isOffline) {
+            return await this.refreshConfigCoreAsync(latestConfig);
+        }
+        else {
+            this.logOfflineModeWarning();
+            return latestConfig;
+        }
     }
 
     protected async refreshConfigCoreAsync(latestConfig: ProjectConfig | null): Promise<ProjectConfig | null> {
         const newConfig = await new Promise<ProjectConfig | null>(resolve => this.fetchLogic(latestConfig, 0, resolve));
-        
+
         const configContentHasChanged = !ProjectConfig.equals(latestConfig, newConfig);
         // NOTE: Reason why the usage of the non-null assertion operator (!) below is safe:
         // when newConfig isn't null and the latest and new configs equal (i.e. configContentHasChanged === false),
@@ -168,5 +196,54 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
             this.options.logger.debug("ConfigServiceBase.fetchLogicInternal(): calling fetchLogic(), recursive call. retries = " + retries);
             this.configFetcher.fetchLogic(this.options, lastEtag, callback);
         }
+    }
+
+    protected get isOfflineExactly(): boolean {
+        return this.status === ConfigServiceStatus.Offline;
+    }
+
+    get isOffline(): boolean {
+        return this.status !== ConfigServiceStatus.Online;
+    }
+
+    protected setOnlineCore() { }
+
+    setOnline(): void {
+        if (this.status === ConfigServiceStatus.Offline) {
+            this.setOnlineCore();
+            this.status = ConfigServiceStatus.Online;
+            this.logStatusChange(this.status);
+        }
+        else if (this.disposed) {
+            this.logDisposedWarning("setOnline")
+        }
+    }
+
+    protected setOfflineCore() { }
+
+    setOffline(): void {
+        if (this.status == ConfigServiceStatus.Online) {
+            this.setOfflineCore();
+            this.status = ConfigServiceStatus.Offline;
+            this.logStatusChange(this.status);
+        }
+        else if (this.disposed) {
+            this.logDisposedWarning("setOnline")
+        }
+    }
+
+    logStatusChange(status: ConfigServiceStatus)
+    {
+        this.options.logger.debug(`Switched to ${ConfigServiceStatus[status]?.toUpperCase()} mode.`);
+    }
+
+    logOfflineModeWarning()
+    {
+        this.options.logger.warn("Client is in offline mode, it can't initiate HTTP calls.");
+    }
+
+    logDisposedWarning(methodName: string)
+    {
+        this.options.logger.warn(`Client has already been disposed, thus ${methodName}() has no effect.`);
     }
 }

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -42,6 +42,8 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
     protected get disposed() { return this.status === ConfigServiceStatus.Disposed; }
 
+    abstract getConfig(): Promise<ProjectConfig | null>;
+
     async refreshConfigAsync(): Promise<ProjectConfig | null> {
         const latestConfig = await this.options.cache.get(this.options.getCacheKey());
         if (!this.isOffline) {

--- a/src/LazyLoadConfigService.ts
+++ b/src/LazyLoadConfigService.ts
@@ -1,6 +1,6 @@
 import { IConfigService, ConfigServiceBase} from "./ConfigServiceBase";
 import { LazyLoadOptions} from "./ConfigCatClientOptions";
-import { IConfigFetcher } from "./index";
+import { IConfigCatLogger, IConfigFetcher } from "./index";
 import { ProjectConfig } from "./ProjectConfig";
 
 export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> implements IConfigService {
@@ -17,12 +17,21 @@ export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> im
     async getConfig(): Promise<ProjectConfig | null> {
         this.options.logger.debug("LazyLoadConfigService.getConfig() called.");
 
+        function logExpired(logger: IConfigCatLogger, appendix: string = "") {
+            logger.debug(`LazyLoadConfigService.getConfig(): cache is empty or expired${appendix}.`);
+        }
+
         const config = await this.options.cache.get(this.options.getCacheKey());
 
         if (ProjectConfig.isExpired(config, this.cacheTimeToLiveSeconds * 1000)) {
-            this.options.logger.debug("LazyLoadConfigService.getConfig(): cache is empty or expired, calling refreshLogicBaseAsync().");
-
-            return await this.refreshConfigCoreAsync(config);
+            if (!this.isOffline) {
+                logExpired(this.options.logger, ", calling refreshConfigCoreAsync()");
+                return await this.refreshConfigCoreAsync(config);
+            }
+            else {
+                logExpired(this.options.logger);
+                return config;
+            }
         }
 
         this.options.logger.debug("LazyLoadConfigService.getConfig(): cache is valid, returning from cache.");

--- a/src/ManualPollConfigService.ts
+++ b/src/ManualPollConfigService.ts
@@ -3,7 +3,7 @@ import { ManualPollOptions } from "./ConfigCatClientOptions";
 import { IConfigFetcher } from "./index";
 import { ProjectConfig } from "./ProjectConfig";
 
-export class ManualPollService extends ConfigServiceBase<ManualPollOptions> implements IConfigService {
+export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions> implements IConfigService {
 
     constructor(configFetcher: IConfigFetcher, options: ManualPollOptions) {
 

--- a/test/ConfigServiceBaseTests.ts
+++ b/test/ConfigServiceBaseTests.ts
@@ -9,7 +9,7 @@ import { assert } from "chai";
 import { InMemoryCache } from "../src/Cache";
 import { delay } from "../src/Utils";
 import { FakeCache } from "./helpers/fakes";
-import { ManualPollService } from "../src/ManualPollService";
+import { ManualPollConfigService } from "../src/ManualPollConfigService";
 
 describe("ConfigServiceBaseTests", () => {
 
@@ -624,7 +624,7 @@ describe("ConfigServiceBaseTests", () => {
             {},
             cache);
 
-        const service = new ManualPollService(fetcherMock.object(), options);
+        const service = new ManualPollConfigService(fetcherMock.object(), options);
 
         // Act
 
@@ -656,7 +656,7 @@ describe("ConfigServiceBaseTests", () => {
 
         cache.set(options.getCacheKey(), cachedPc);
 
-        const service = new ManualPollService(fetcherMock.object(), options);
+        const service = new ManualPollConfigService(fetcherMock.object(), options);
 
         // Act
 

--- a/test/DataGovernanceTests.ts
+++ b/test/DataGovernanceTests.ts
@@ -267,6 +267,8 @@ export class FakeConfigServiceBase extends ConfigServiceBase<FakeOptions> {
         super(new FakeConfigFetcher(), new FakeOptions(baseUrl, dataGovernance));
     }
 
+    getConfig(): Promise<ProjectConfig | null> { return Promise.resolve(null); }
+
     refreshLogicAsync(): Promise<ProjectConfig | null> {
         return this.refreshConfigCoreAsync(null);
     }


### PR DESCRIPTION
### Describe the purpose of your pull request

* Adds `IConfigCatClient.isOffline` property, `IConfigCatClient.setOnline` and `IConfigCatClient.setOffline` methods.
* Renames `ManualPollService` to `ManualPollConfigService` for consistent naming. (This is just a suggestion though, we can scrap it if you disagree.)

It's also worth mentioning that in the current implementation the client goes into offline mode implicitly when gets disposed. This also prevents the user from making forced cache refreshes (`forceRefresh`/`forceRefreshAsync`) on a disposed client. This is in line with the .NET SDK behavior.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
