### PR TITLE
Fix wrong null/undefined config handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-common",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-common",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-common",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "ConfigCat is a configuration as a service that lets you manage your features and configurations without actually deploying new code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -63,8 +63,8 @@ export class AutoPollConfigService extends ConfigServiceBase implements IConfigS
             if (weDontHaveCachedYetButHaveNew || weHaveBothButTheyDiffers) {
                 this.configChanged();
             }
-
-            resolve(newConfig)
+            
+            resolve(newConfig);
         });
     }
 

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -321,7 +321,7 @@ export class ConfigCatClient implements IConfigCatClient {
                     return;
                 }
                 const remoteConfig = await this.configService?.getConfig();
-                const remoteSettings = getSettingsFromConfig(remoteConfig?.ConfigJSON ?? {});
+                const remoteSettings = getSettingsFromConfig(remoteConfig?.ConfigJSON);
 
                 if (this.options.flagOverrides.behaviour == OverrideBehaviour.LocalOverRemote) {
                     resolve({ ...remoteSettings, ...localSettings });

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -47,8 +47,8 @@ export abstract class ConfigServiceBase {
         this.baseConfig.logger.debug("ConfigServiceBase.fetchLogic() - called.");
         const calledBaseUrl = this.baseConfig.baseUrl;
         this.fetchLogicInternal(this.baseConfig, lastEtag, retries, (result) => {
-            this.baseConfig.logger.debug("ConfigServiceBase.fetchLogic(): result.status: " + result.status);
-            if (result.status != FetchStatus.Fetched || ProjectConfig.compareEtags(lastEtag ?? '', result.eTag)) {
+            this.baseConfig.logger.debug("ConfigServiceBase.fetchLogic(): result.status: " + result?.status);
+            if (!result || result.status != FetchStatus.Fetched || ProjectConfig.compareEtags(lastEtag ?? '', result.eTag)) {
                 this.baseConfig.logger.debug("ConfigServiceBase.fetchLogic(): result.status != FetchStatus.Fetched or etags are the same. Returning null.");
                 callback(null);
                 return;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -3,6 +3,10 @@ import { ConfigFile, Setting } from "./ProjectConfig";
 export const isUndefined = (comp: any) => comp === undefined;
 
 export function getSettingsFromConfig(json: any): { [name: string]: Setting } {
+    if (!json) {
+        return {};
+    }
+
     return Object.fromEntries(Object.entries(json[ConfigFile.FeatureFlags]).map(([key, value]) => {
         return [key, Setting.fromJson(value)];
     }));

--- a/test/OverrideTests.ts
+++ b/test/OverrideTests.ts
@@ -90,6 +90,7 @@ describe("Local Overrides", () => {
                 }),
                 behaviour: OverrideBehaviour.RemoteOverLocal
             },
+            maxInitWaitTimeSeconds: 1
         }, null);
         let client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 

--- a/test/OverrideTests.ts
+++ b/test/OverrideTests.ts
@@ -76,6 +76,27 @@ describe("Local Overrides", () => {
         assert.equal(await client.getValueAsync("nonexisting", false), true);
     });
 
+    it("Values from map - RemoteOverLocal - failing remote", async () => {
+        let configCatKernel: FakeConfigCatKernel = {
+            configFetcher: new FakeConfigFetcherBase(null),
+            sdkType: "common",
+            sdkVersion: "1.0.0"
+        };
+        let options: AutoPollOptions = new AutoPollOptions("localhost", "common", "1.0.0", {
+            flagOverrides: {
+                dataSource: new MapOverrideDataSource({
+                    fakeKey: true,
+                    nonexisting: true
+                }),
+                behaviour: OverrideBehaviour.RemoteOverLocal
+            },
+        }, null);
+        let client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
+
+        assert.equal(await client.getValueAsync("fakeKey", false), true);
+        assert.equal(await client.getValueAsync("nonexisting", false), true);
+    });
+
     it("Values from map - another map style", async () => {
         let dataSource: { [name: string]: any } = {}
         dataSource["enabled-feature"] = true;


### PR DESCRIPTION
### Describe the purpose of your pull request

There was a missing check in `getSettingsFromConfig()`, and the value `{}` was not handled correctly that we used as default whenever we didn't get a valid config.json from the `ConfigService` and flag overrides was active.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
