### PR TITLE
Improves config fetcher logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "coverage": "nyc npm run test",
     "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json && tsc -p tsconfig.legacy.json",
     "prepare": "npm run build",
-    "test": "node --expose-gc node_modules/mocha/bin/_mocha --require ts-node/register test/**/*.ts --exit --timeout 30000",
-    "test-debug": "node --expose-gc node_modules/mocha/bin/_mocha --fgrep \"TITLE_OF_TEST\" --require ts-node/register test/**/*.ts --exit --timeout 30000"
+    "test": "node --expose-gc node_modules/mocha/bin/_mocha --require ts-node/register 'test/**/*.ts' --exit --timeout 30000",
+    "test-debug": "node --expose-gc node_modules/mocha/bin/_mocha --fgrep \"TITLE_OF_TEST\" --require ts-node/register 'test/**/*.ts' --exit --timeout 30000"
   },
   "keywords": [
     "configcat",

--- a/samples/deno-sandbox/fake-config-fetcher.ts
+++ b/samples/deno-sandbox/fake-config-fetcher.ts
@@ -1,21 +1,21 @@
-import { FetchResult, FetchStatus, IConfigFetcher, OptionsBase } from "src/index.ts";
+import { IConfigFetcher, OptionsBase } from "src/index.ts";
+import type { IFetchResponse } from "../../src/ConfigFetcher.ts";
 
-export class FakeConfigFetcher implements IConfigFetcher
-{
-    private currentFetchResult = FetchResult.error();
+export class FakeConfigFetcher implements IConfigFetcher {
+    private currentFetchResponse: IFetchResponse = { statusCode: 404, reasonPhrase: "Not Found" };
     private currentETag = 0;
 
-    fetchLogic(_options: OptionsBase, lastEtag: string | null, callback: (result: FetchResult) => void) {
-        callback(this.currentFetchResult.status === FetchStatus.Fetched && this.currentFetchResult.eTag === lastEtag
-            ? FetchResult.notModified()
-            : this.currentFetchResult);
+    fetchLogic(_options: OptionsBase, lastEtag: string | null): Promise<IFetchResponse> {
+        return Promise.resolve(this.currentFetchResponse.statusCode == 200 && (this.currentETag + "") === lastEtag
+            ? <IFetchResponse>{ statusCode: 304, reasonPhrase: "Not Modified" }
+            : this.currentFetchResponse);
     }
 
     setSuccess(configJson: string) {
-        this.currentFetchResult = FetchResult.success(configJson, (++this.currentETag) + "");
+        this.currentFetchResponse = { statusCode: 200, reasonPhrase: "OK", eTag: (++this.currentETag) + "", body: configJson };
     }
-    
-    setError() {
-        this.currentFetchResult = FetchResult.error();
+
+    setError(statusCode: number, reasonPhrase: string) {
+        this.currentFetchResponse = { statusCode, reasonPhrase };
     }
 }

--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -28,7 +28,13 @@ export class FetchResult {
     }
 }
 
+export interface IFetchResponse {
+    statusCode: number;
+    reasonPhrase: string;
+    eTag?: string;
+    body?: string;
+}
+
 export interface IConfigFetcher {
-    /** @remarks Implementers must ensure that callback is called under all circumstances, i.e. in case of successful or failed requests and potential exceptions as well! */
-    fetchLogic(options: OptionsBase, lastEtag: string | null, callback: (result: FetchResult) => void): void;
+    fetchLogic(options: OptionsBase, lastEtag: string | null): Promise<IFetchResponse>;
 }

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -149,6 +149,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
                     options.logger.debug("ConfigServiceBase.fetchLogicAsync(): content was not modified. Returning last config with updated timestamp.");
                     return [FetchResult.notModified(), new ProjectConfig(new Date().getTime(), lastConfig.ConfigJSON, lastConfig.HttpETag)];
 
+                case 403: // Forbidden
                 case 404: // Not Found
                     errorMessage = "Double-check your SDK Key at https://app.configcat.com/sdkkey";
                     options.logger.error(errorMessage);

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -1,5 +1,5 @@
 import { OptionsBase } from "./ConfigCatClientOptions";
-import { FetchResult, FetchStatus, IConfigFetcher } from "./ConfigFetcher";
+import { FetchResult, FetchStatus, IConfigFetcher, IFetchResponse } from "./ConfigFetcher";
 import { ConfigFile, Preferences, ProjectConfig } from "./ProjectConfig";
 
 export class RefreshResult {
@@ -124,57 +124,82 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
         const options = this.options;
         options.logger.debug("ConfigServiceBase.fetchLogicAsync() - called.");
 
-        const [result, configJson] = await this.fetchRequestAsync(lastConfig?.HttpETag ?? null);
+        let errorMessage;
+        try {
+            const [response, configJson] = await this.fetchRequestAsync(lastConfig?.HttpETag ?? null);
 
-        switch (result.status) {
-            case FetchStatus.Fetched:
-                if (!configJson) {
-                    options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was successful but response is invalid. Returning null.");
-                    return [result, null];
-                }
+            switch (response.statusCode) {
+                case 200: // OK
+                    if (!configJson) {
+                        errorMessage = "Fetch was successful but HTTP response was invalid";
+                        options.logger.debug(`ConfigServiceBase.fetchLogicAsync(): ${errorMessage.charAt(0).toLowerCase()}${errorMessage.slice(1)}. Returning null.`);
+                        return [FetchResult.error(errorMessage), null];
+                    }
 
-                options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was successful. Returning new config.");
-                return [result, new ProjectConfig(new Date().getTime(), configJson, result.eTag)];
-            case FetchStatus.NotModified:
-                if (!lastConfig) {
-                    options.logger.debug(`ConfigServiceBase.fetchLogicAsync(): received status '${FetchStatus[result.status]}' when no config was cached locally. Returning null.`);
-                    return [result, null];
-                }
+                    options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was successful. Returning new config.");
+                    return [FetchResult.success(response.body!, response.eTag!), new ProjectConfig(new Date().getTime(), configJson, response.eTag)];
 
-                options.logger.debug("ConfigServiceBase.fetchLogicAsync(): content was not modified. Returning last config with updated timestamp.");
-                return [result, new ProjectConfig(new Date().getTime(), lastConfig.ConfigJSON, lastConfig.HttpETag)];
-            case FetchStatus.Errored:
-                options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning null.");
-                return [result, null];
-            default:
-                options.logger.error(`ConfigServiceBase.fetchLogicAsync(): invalid fetch status '${FetchStatus[result.status]}'. Returning null.`);
-                return [result, null];
+                case 304: // Not Modified
+                    if (!lastConfig) {
+                        errorMessage = `HTTP response ${response.statusCode} ${response.reasonPhrase} was received when no config is cached locally`;
+                        options.logger.debug(`ConfigServiceBase.fetchLogicAsync(): ${errorMessage.charAt(0).toLowerCase()}${errorMessage.slice(1)}. Returning null.`);
+                        return [FetchResult.error(errorMessage), null];
+                    }
+
+                    options.logger.debug("ConfigServiceBase.fetchLogicAsync(): content was not modified. Returning last config with updated timestamp.");
+                    return [FetchResult.notModified(), new ProjectConfig(new Date().getTime(), lastConfig.ConfigJSON, lastConfig.HttpETag)];
+
+                case 404: // Not Found
+                    errorMessage = "Double-check your SDK Key at https://app.configcat.com/sdkkey";
+                    options.logger.error(errorMessage);
+                    options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning last config (if any) with updated timestamp.");
+                    return [FetchResult.error(errorMessage), lastConfig ? new ProjectConfig(new Date().getTime(), lastConfig.ConfigJSON, lastConfig.HttpETag) : null];
+
+                default:
+                    errorMessage = `Unexpected HTTP response was received: ${response.statusCode} ${response.reasonPhrase}`;
+                    options.logger.error(errorMessage);
+                    options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning null.");
+                    return [FetchResult.error(errorMessage), null];
+            }
+        }
+        catch (err) {
+            errorMessage = "Unexpected error occured during fetching.";
+            options.logger.error(errorMessage, err);
+            options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning null.");
+            return [FetchResult.error(errorMessage, err), null];
         }
     }
 
-    private async fetchRequestAsync(lastETag: string | null, maxRetryCount = 2): Promise<[FetchResult, any?]> {
+    private async fetchRequestAsync(lastETag: string | null, maxRetryCount = 2): Promise<[IFetchResponse, any?]> {
         const options = this.options;
         options.logger.debug("ConfigServiceBase.fetchRequestAsync() - called.");
 
         for (let retryNumber = 0; ; retryNumber++) {
             options.logger.debug(`ConfigServiceBase.fetchRequestAsync(): calling fetchLogic()${retryNumber > 0 ? `, retry ${retryNumber}/${maxRetryCount}` : ""}`);
-            const result = await new Promise<FetchResult>(resolve => this.configFetcher.fetchLogic(options, lastETag, resolve));
+            const response = await this.configFetcher.fetchLogic(options, lastETag);
 
-            if (result.status !== FetchStatus.Fetched) {
-                return [result];
+            if (response.statusCode !== 200) {
+                return [response];
             }
 
-            if (!result.responseBody) {
+            if (!response.body) {
                 options.logger.debug("ConfigServiceBase.fetchRequestAsync(): no response body.");
-                return [result];
+                return [response];
             }
 
-            const configJSON = JSON.parse(result.responseBody);
+            let configJSON: any;
+            try {
+                configJSON = JSON.parse(response.body);
+            }
+            catch {
+                options.logger.debug("ConfigServiceBase.fetchRequestAsync(): invalid response body.");
+                return [response];
+            }
 
             const preferences = configJSON[ConfigFile.Preferences];
             if (!preferences) {
                 options.logger.debug("ConfigServiceBase.fetchRequestAsync(): preferences is empty.");
-                return [result, configJSON];
+                return [response, configJSON];
             }
 
             const baseUrl = preferences[Preferences.BaseUrl];
@@ -182,7 +207,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
             // If the base_url is the same as the last called one, just return the response.
             if (!baseUrl || baseUrl == options.baseUrl) {
                 options.logger.debug("ConfigServiceBase.fetchRequestAsync(): baseUrl OK.");
-                return [result, configJSON];
+                return [response, configJSON];
             }
 
             const redirect = preferences[Preferences.Redirect];
@@ -191,13 +216,13 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
             // the SDK should not redirect the calls and it just have to return the response.
             if (options.baseUrlOverriden && redirect !== 2) {
                 options.logger.debug("ConfigServiceBase.fetchRequestAsync(): options.baseUrlOverriden && redirect !== 2.");
-                return [result, configJSON];
+                return [response, configJSON];
             }
 
             options.baseUrl = baseUrl;
 
             if (redirect === 0) {
-                return [result, configJSON];
+                return [response, configJSON];
             }
 
             if (redirect === 1) {
@@ -211,7 +236,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
             if (retryNumber >= maxRetryCount) {
                 options.logger.error("Redirect loop during config.json fetch. Please contact support@configcat.com.");
-                return [result, configJSON];
+                return [response, configJSON];
             }
         }
     }

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -1,5 +1,5 @@
 import { OptionsBase } from "./ConfigCatClientOptions";
-import { FetchResult, FetchStatus, IConfigFetcher, IFetchResponse } from "./ConfigFetcher";
+import { FetchError, FetchResult, FetchStatus, IConfigFetcher, IFetchResponse } from "./ConfigFetcher";
 import { ConfigFile, Preferences, ProjectConfig } from "./ProjectConfig";
 
 export class RefreshResult {
@@ -163,7 +163,10 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
             }
         }
         catch (err) {
-            errorMessage = "Unexpected error occured during fetching.";
+            const errorMessage = err instanceof FetchError
+                ? err.message
+                : "Unexpected error occurred during fetching.";
+
             options.logger.error(errorMessage, err);
             options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning null.");
             return [FetchResult.error(errorMessage, err), null];

--- a/src/ProjectConfig.ts
+++ b/src/ProjectConfig.ts
@@ -19,8 +19,20 @@ export class ProjectConfig {
      * Determines whether the specified ProjectConfig instances are considered equal.
      */
     public static equals(projectConfig1: ProjectConfig | null, projectConfig2: ProjectConfig | null): boolean {
-        // If both configs are null, we consider them equal.
-        return projectConfig1 ? !!projectConfig2 && this.compareEtags(projectConfig1.HttpETag, projectConfig2.HttpETag) : !projectConfig2;
+        if (!projectConfig1) {
+            // If both configs are null, we consider them equal.
+            return !projectConfig2;
+        }
+
+        if (!projectConfig2) {
+            return false;
+        }
+
+        // When both ETags are available, we don't need to check the JSON content
+        // (because of how HTTP ETags work - see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag).
+        return !!projectConfig1.HttpETag && !!projectConfig2.HttpETag
+            ? this.compareEtags(projectConfig1.HttpETag, projectConfig2.HttpETag)
+            : JSON.stringify(projectConfig1.ConfigJSON) === JSON.stringify(projectConfig2.ConfigJSON);
     }
 
     public static compareEtags(etag1?: string, etag2?: string): boolean {

--- a/test/DataGovernanceTests.ts
+++ b/test/DataGovernanceTests.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import "mocha";
 import { DataGovernance, OptionsBase } from "../src/ConfigCatClientOptions";
-import { FetchResult, IConfigFetcher } from "../src/ConfigFetcher";
+import { FetchResult, IConfigFetcher, IFetchResponse } from "../src/ConfigFetcher";
 import { ConfigServiceBase } from "../src/ConfigServiceBase";
 import { ProjectConfig } from "../src/ProjectConfig";
 
@@ -247,13 +247,13 @@ export class FakeConfigFetcher implements IConfigFetcher {
         this.responses[url] = fetchResult;
     }
 
-    fetchLogic(options: OptionsBase, lastEtag: string | null, callback: (result: FetchResult) => void): void {
+    fetchLogic(options: OptionsBase, lastEtag: string | null): Promise<IFetchResponse> {
         const projectConfig = this.responses[options.getUrl()];
         if (!projectConfig) {
             assert.fail("ConfigFetcher not prepared for " + options.baseUrl);
         }
         this.calls.push(options.getUrl());
-        callback(projectConfig);
+        return Promise.resolve<IFetchResponse>({ statusCode: 200, reasonPhrase: "OK", eTag: projectConfig.eTag, body: projectConfig.responseBody });
     }
 }
 

--- a/test/ProjectConfigTests.ts
+++ b/test/ProjectConfigTests.ts
@@ -31,9 +31,30 @@ describe("ProjectConfig", () => {
     assert.isTrue(ProjectConfig.equals(actual, expected));
   });
 
-  it("Equals - Actual etag is 'undefined' - Should not equal", () => {
+  it("Equals - One of the tags is 'undefined' and json strings are equal - Should equal", () => {
     const actual: ProjectConfig = new ProjectConfig(1, "{}", undefined);
     const expected: ProjectConfig = new ProjectConfig(1, "{}", "W/\"etag\"");
+
+    assert.isTrue(ProjectConfig.equals(actual, expected));
+  });
+
+  it("Equals - Both tags are 'undefined' and json strings are equal - Should equal", () => {
+    const actual: ProjectConfig = new ProjectConfig(1, "{}", undefined);
+    const expected: ProjectConfig = new ProjectConfig(1, "{}", undefined);
+
+    assert.isTrue(ProjectConfig.equals(actual, expected));
+  });
+
+  it("Equals - One of the tags is 'undefined' and json strings are not equal - Should not equal", () => {
+    const actual: ProjectConfig = new ProjectConfig(1, "{\"f\": {}}", "W/\"etag\"");
+    const expected: ProjectConfig = new ProjectConfig(1, "{}", undefined);
+
+    assert.isFalse(ProjectConfig.equals(actual, expected));
+  });
+
+  it("Equals - Both tags are 'undefined' and json strings are not equal - Should not equal", () => {
+    const actual: ProjectConfig = new ProjectConfig(1, "{\"f\": {}}", undefined);
+    const expected: ProjectConfig = new ProjectConfig(1, "{}", undefined);
 
     assert.isFalse(ProjectConfig.equals(actual, expected));
   });


### PR DESCRIPTION
### Describe the purpose of your pull request

Breaking changes:
* Changes `IConfigFetcher.fetchLogic` to return a `Promise` instead of accepting a callback. Also changes the data structure returned (`IFetchResponse` instead of `FetchResult`).
* Changes `ProjectConfig.equals` to fall back to comparing the actual configs when both ETags are not available.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
