### PR TITLE
#68 add pollIntervalSeconds isNaN validation

### DIFF
--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -18,7 +18,7 @@ export interface IOptions {
     baseUrl?: string | null;
     /** You can set a base_url if you want to use a proxy server between your application and ConfigCat */
     proxy?: string | null;
-    /** Default: Global. Set this parameter to be in sync with the Data Governance preference on the Dashboard: 
+    /** Default: Global. Set this parameter to be in sync with the Data Governance preference on the Dashboard:
      * https://app.configcat.com/organization/data-governance (Only Organization Admins have access) */
     dataGovernance?: DataGovernance | null;
     /**
@@ -56,7 +56,7 @@ export abstract class OptionsBase implements IOptions {
     public cache: ICache;
 
     public flagOverrides?: FlagOverrides;
-    
+
     public defaultUser?: User | null;
 
     constructor(apiKey: string, clientVersion: string, options?: IOptions | null, defaultCache?: ICache | null) {
@@ -157,11 +157,11 @@ export class AutoPollOptions extends OptionsBase implements IAutoPollOptions {
             }
         }
 
-        if (this.pollIntervalSeconds < 1) {
+        if (this.pollIntervalSeconds < 1 || isNaN(this.pollIntervalSeconds)) {
             throw new Error("Invalid 'pollIntervalSeconds' value");
         }
 
-        if (this.maxInitWaitTimeSeconds < 0) {
+        if (this.maxInitWaitTimeSeconds < 0 || isNaN(this.maxInitWaitTimeSeconds)) {
             throw new Error("Invalid 'maxInitWaitTimeSeconds' value");
         }
     }

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -157,11 +157,11 @@ export class AutoPollOptions extends OptionsBase implements IAutoPollOptions {
             }
         }
 
-        if (this.pollIntervalSeconds < 1 || isNaN(this.pollIntervalSeconds)) {
+        if (!(this.pollIntervalSeconds >= 1 && (typeof this.pollIntervalSeconds === 'number'))) {
             throw new Error("Invalid 'pollIntervalSeconds' value");
         }
 
-        if (this.maxInitWaitTimeSeconds < 0 || isNaN(this.maxInitWaitTimeSeconds)) {
+        if (!(this.maxInitWaitTimeSeconds >= 0 && (typeof this.maxInitWaitTimeSeconds === 'number'))) {
             throw new Error("Invalid 'maxInitWaitTimeSeconds' value");
         }
     }

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -114,6 +114,30 @@ describe("Options", () => {
     }).to.throw("Invalid 'pollIntervalSeconds' value");
   });
 
+  it("AutoPollOptions initialization With boolean value 'pollIntervalSeconds' ShouldThrowError", () => {
+    const myConfig = new Map();
+    myConfig.set('pollIntervalSeconds', true);
+    expect(() => {
+      new AutoPollOptions("APIKEY", "common", "1.0.0", { pollIntervalSeconds: myConfig.get('pollIntervalSeconds') }, null);
+    }).to.throw("Invalid 'pollIntervalSeconds' value");
+  });
+
+  it("AutoPollOptions initialization With whitespaces value 'pollIntervalSeconds' ShouldThrowError", () => {
+    const myConfig = new Map();
+    myConfig.set('pollIntervalSeconds', ' ');
+    expect(() => {
+      new AutoPollOptions("APIKEY", "common", "1.0.0", { pollIntervalSeconds: myConfig.get('pollIntervalSeconds') }, null);
+    }).to.throw("Invalid 'pollIntervalSeconds' value");
+  });
+
+  it("AutoPollOptions initialization With new line value 'pollIntervalSeconds' ShouldThrowError", () => {
+    const myConfig = new Map();
+    myConfig.set('pollIntervalSeconds', '\n');
+    expect(() => {
+      new AutoPollOptions("APIKEY", "common", "1.0.0", { pollIntervalSeconds: myConfig.get('pollIntervalSeconds') }, null);
+    }).to.throw("Invalid 'pollIntervalSeconds' value");
+  });
+
   it("AutoPollOptions initialization With 0 'pollIntervalSeconds' ShouldThrowError", () => {
     expect(() => {
       new AutoPollOptions("APIKEY", "common", "1.0.0", { pollIntervalSeconds: -1 }, null);
@@ -148,6 +172,30 @@ describe("Options", () => {
     myConfig.set('maxInitWaitTimeSeconds', undefined);
     expect(() => {
       new AutoPollOptions("APIKEY", "common", "1.0.0", { maxInitWaitTimeSeconds: +(myConfig.get('maxInitWaitTimeSeconds')) }, null);
+    }).to.throw("Invalid 'maxInitWaitTimeSeconds' value");
+  });
+
+  it("AutoPollOptions initialization With boolean value 'maxInitWaitTimeSeconds' ShouldThrowError", () => {
+    const myConfig = new Map();
+    myConfig.set('maxInitWaitTimeSeconds', true);
+    expect(() => {
+      new AutoPollOptions("APIKEY", "common", "1.0.0", { maxInitWaitTimeSeconds: myConfig.get('maxInitWaitTimeSeconds') }, null);
+    }).to.throw("Invalid 'maxInitWaitTimeSeconds' value");
+  });
+
+  it("AutoPollOptions initialization With whitespaces value 'maxInitWaitTimeSeconds' ShouldThrowError", () => {
+    const myConfig = new Map();
+    myConfig.set('maxInitWaitTimeSeconds', ' ');
+    expect(() => {
+      new AutoPollOptions("APIKEY", "common", "1.0.0", { maxInitWaitTimeSeconds: myConfig.get('maxInitWaitTimeSeconds') }, null);
+    }).to.throw("Invalid 'maxInitWaitTimeSeconds' value");
+  });
+
+  it(`AutoPollOptions initialization With new line value 'maxInitWaitTimeSeconds' ShouldThrowError`, () => {
+    const myConfig = new Map();
+    myConfig.set('maxInitWaitTimeSeconds', '\n');
+    expect(() => {
+      new AutoPollOptions("APIKEY", "common", "1.0.0", { maxInitWaitTimeSeconds: myConfig.get('maxInitWaitTimeSeconds') }, null);
     }).to.throw("Invalid 'maxInitWaitTimeSeconds' value");
   });
 

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -106,6 +106,14 @@ describe("Options", () => {
     }).to.throw("Invalid 'pollIntervalSeconds' value");
   });
 
+  it("AutoPollOptions initialization With NaN 'pollIntervalSeconds' ShouldThrowError", () => {
+    const myConfig = new Map();
+    myConfig.set('pollIntervalSeconds', undefined);
+    expect(() => {
+      new AutoPollOptions("APIKEY", "common", "1.0.0", { pollIntervalSeconds: +(myConfig.get('pollIntervalSeconds')) }, null);
+    }).to.throw("Invalid 'pollIntervalSeconds' value");
+  });
+
   it("AutoPollOptions initialization With 0 'pollIntervalSeconds' ShouldThrowError", () => {
     expect(() => {
       new AutoPollOptions("APIKEY", "common", "1.0.0", { pollIntervalSeconds: -1 }, null);
@@ -132,6 +140,14 @@ describe("Options", () => {
   it("AutoPollOptions initialization With -1 'maxInitWaitTimeSeconds' ShouldThrowError", () => {
     expect(() => {
       new AutoPollOptions("APIKEY", "common", "1.0.0", { maxInitWaitTimeSeconds: -1 }, null);
+    }).to.throw("Invalid 'maxInitWaitTimeSeconds' value");
+  });
+
+  it("AutoPollOptions initialization With NaN 'maxInitWaitTimeSeconds' ShouldThrowError", () => {
+    const myConfig = new Map();
+    myConfig.set('maxInitWaitTimeSeconds', undefined);
+    expect(() => {
+      new AutoPollOptions("APIKEY", "common", "1.0.0", { maxInitWaitTimeSeconds: +(myConfig.get('maxInitWaitTimeSeconds')) }, null);
     }).to.throw("Invalid 'maxInitWaitTimeSeconds' value");
   });
 

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -108,9 +108,9 @@ describe("Options", () => {
 
   it("AutoPollOptions initialization With NaN 'pollIntervalSeconds' ShouldThrowError", () => {
     const myConfig = new Map();
-    myConfig.set('pollIntervalSeconds', undefined);
+    myConfig.set('pollIntervalSeconds', NaN);
     expect(() => {
-      new AutoPollOptions("APIKEY", "common", "1.0.0", { pollIntervalSeconds: +(myConfig.get('pollIntervalSeconds')) }, null);
+      new AutoPollOptions("APIKEY", "common", "1.0.0", { pollIntervalSeconds: myConfig.get('pollIntervalSeconds') }, null);
     }).to.throw("Invalid 'pollIntervalSeconds' value");
   });
 
@@ -169,9 +169,9 @@ describe("Options", () => {
 
   it("AutoPollOptions initialization With NaN 'maxInitWaitTimeSeconds' ShouldThrowError", () => {
     const myConfig = new Map();
-    myConfig.set('maxInitWaitTimeSeconds', undefined);
+    myConfig.set('maxInitWaitTimeSeconds', NaN);
     expect(() => {
-      new AutoPollOptions("APIKEY", "common", "1.0.0", { maxInitWaitTimeSeconds: +(myConfig.get('maxInitWaitTimeSeconds')) }, null);
+      new AutoPollOptions("APIKEY", "common", "1.0.0", { maxInitWaitTimeSeconds: myConfig.get('maxInitWaitTimeSeconds') }, null);
     }).to.throw("Invalid 'maxInitWaitTimeSeconds' value");
   });
 


### PR DESCRIPTION
add maxInitWaitTimeSeconds isNaN validation
FIx issue 68
### Describe the purpose of your pull request

Passing NaN as pollIntervalSeconds interval causes setTimeout infinity call, that in turn million request to config-cat CDN

### Related issues (only if applicable)

Provide links to issues relating to this pull request
https://github.com/configcat/common-js/issues/68
### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
