### PR TITLE
Improves type safety of setting evaluation methods

### DIFF
--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -10,7 +10,7 @@ import type { HookEvents, Hooks, IProvidesHooks } from "./Hooks";
 import { LazyLoadConfigService } from "./LazyLoadConfigService";
 import { ManualPollConfigService } from "./ManualPollConfigService";
 import { ConfigFile, ProjectConfig, RolloutPercentageItem, RolloutRule, Setting } from "./ProjectConfig";
-import { checkSettingsAvailable, evaluate, evaluateAll, evaluateAllVariationIds, SettingTypeOf, evaluateVariationId, evaluationDetailsFromDefaultValue, evaluationDetailsFromDefaultVariationId, IEvaluationDetails, IRolloutEvaluator, RolloutEvaluator, SettingValue, User, ensureAllowedDefaultValue } from "./RolloutEvaluator";
+import { checkSettingsAvailable, ensureAllowedDefaultValue, evaluate, evaluateAll, evaluateAllVariationIds, evaluateVariationId, evaluationDetailsFromDefaultValue, evaluationDetailsFromDefaultVariationId, IEvaluationDetails, IRolloutEvaluator, RolloutEvaluator, SettingTypeOf, SettingValue, User, VariationIdTypeOf, VariationIdValue } from "./RolloutEvaluator";
 import { errorToString, getSettingsFromConfig, getTimestampAsDate } from "./Utils";
 
 export interface IConfigCatClient extends IProvidesHooks {
@@ -18,18 +18,18 @@ export interface IConfigCatClient extends IProvidesHooks {
     /** Returns the value of a feature flag or setting based on it's key
      * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please use the getValueAsync() method instead.
      */
-    getValue<T extends SettingValue = any>(key: string, defaultValue: T, callback: (value: SettingTypeOf<T>) => void, user?: User): void;
+    getValue<T extends SettingValue>(key: string, defaultValue: T, callback: (value: SettingTypeOf<T>) => void, user?: User): void;
 
     /** Returns the value of a feature flag or setting based on it's key */
-    getValueAsync<T extends SettingValue = any>(key: string, defaultValue: T, user?: User): Promise<SettingTypeOf<T>>;
+    getValueAsync<T extends SettingValue>(key: string, defaultValue: T, user?: User): Promise<SettingTypeOf<T>>;
 
     /** Returns the value along with evaluation details of a feature flag or setting based on it's key
      * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please use the getValueDetailsAsync() method instead.
      */
-    getValueDetails<T extends SettingValue = any>(key: string, defaultValue: T, callback: (evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>) => void, user?: User): void;
+    getValueDetails<T extends SettingValue>(key: string, defaultValue: T, callback: (evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>) => void, user?: User): void;
 
     /** Returns the value along with evaluation details of a feature flag or setting based on it's key */
-    getValueDetailsAsync<T extends SettingValue = any>(key: string, defaultValue: T, user?: User): Promise<IEvaluationDetails<SettingTypeOf<T>>>;
+    getValueDetailsAsync<T extends SettingValue>(key: string, defaultValue: T, user?: User): Promise<IEvaluationDetails<SettingTypeOf<T>>>;
 
     /** Downloads the latest feature flag and configuration values
      * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please use the forceRefreshAsync() method instead.
@@ -50,12 +50,12 @@ export interface IConfigCatClient extends IProvidesHooks {
     /** Returns the Variation ID (analytics) of a feature flag or setting based on it's key
      * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please use the getValueDetails() method instead.
      */
-    getVariationId(key: string, defaultVariationId: any, callback: (variationId: string) => void, user?: User): void;
+    getVariationId<T extends VariationIdValue>(key: string, defaultVariationId: T, callback: (variationId: VariationIdTypeOf<T>) => void, user?: User): void;
 
     /** Returns the Variation ID (analytics) of a feature flag or setting based on it's key
      * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please use the getValueDetailsAsync() method instead.
      */
-    getVariationIdAsync(key: string, defaultVariationId: any, user?: User): Promise<string>;
+    getVariationIdAsync<T extends VariationIdValue>(key: string, defaultVariationId: T, user?: User): Promise<VariationIdTypeOf<T>>;
 
     /** Returns the Variation IDs (analytics) of all feature flags or settings
      * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please use the getAllValueDetails() method instead.
@@ -300,15 +300,15 @@ export class ConfigCatClient implements IConfigCatClient {
         }
     }
     
-    getValue<T extends SettingValue = any>(key: string, defaultValue: T, callback: (value: SettingTypeOf<T>) => void, user?: User): void {
+    getValue<T extends SettingValue>(key: string, defaultValue: T, callback: (value: SettingTypeOf<T>) => void, user?: User): void {
         this.options.logger.debug("getValue() called.");
         this.getValueAsync(key, defaultValue, user).then(callback);
     }
 
-    async getValueAsync<T extends SettingValue = any>(key: string, defaultValue: T, user?: User): Promise<SettingTypeOf<T>> {
+    async getValueAsync<T extends SettingValue>(key: string, defaultValue: T, user?: User): Promise<SettingTypeOf<T>> {
         this.options.logger.debug("getValueAsync() called.");
 
-        let value: any, evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>;
+        let value: SettingTypeOf<T>, evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>;
         let remoteConfig: ProjectConfig | null = null;
         user ??= this.defaultUser;
         try {
@@ -321,22 +321,22 @@ export class ConfigCatClient implements IConfigCatClient {
         catch (err) {
             this.options.logger.error("Error occurred in getValueAsync().", err);
             evaluationDetails = evaluationDetailsFromDefaultValue(key, defaultValue, getTimestampAsDate(remoteConfig), user, errorToString(err), err);
-            value = defaultValue;
+            value = defaultValue as SettingTypeOf<T>;
         }
 
         this.options.hooks.emit("flagEvaluated", evaluationDetails);
         return value;
     }
 
-    getValueDetails<T extends SettingValue = any>(key: string, defaultValue: T, callback: (evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>) => void, user?: User): void {
+    getValueDetails<T extends SettingValue>(key: string, defaultValue: T, callback: (evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>) => void, user?: User): void {
         this.options.logger.debug("getValueDetails() called.");
         this.getValueDetailsAsync(key, defaultValue, user).then(callback);
     }
 
-    async getValueDetailsAsync<T extends SettingValue = any>(key: string, defaultValue: T, user?: User): Promise<IEvaluationDetails<SettingTypeOf<T>>> {
+    async getValueDetailsAsync<T extends SettingValue>(key: string, defaultValue: T, user?: User): Promise<IEvaluationDetails<SettingTypeOf<T>>> {
         this.options.logger.debug("getValueDetailsAsync() called.");
 
-        let evaluationDetails: IEvaluationDetails;
+        let evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>;
         let remoteConfig: ProjectConfig | null = null;
         user ??= this.defaultUser;
         try {
@@ -398,27 +398,27 @@ export class ConfigCatClient implements IConfigCatClient {
         }
     }
 
-    getVariationId(key: string, defaultVariationId: any, callback: (variationId: string) => void, user?: User): void {
+    getVariationId<T extends VariationIdValue>(key: string, defaultVariationId: T, callback: (variationId: VariationIdTypeOf<T>) => void, user?: User): void {
         this.options.logger.debug("getVariationId() called.");
         this.getVariationIdAsync(key, defaultVariationId, user).then(callback);
     }
 
-    async getVariationIdAsync(key: string, defaultVariationId: any, user?: User): Promise<string> {
+    async getVariationIdAsync<T extends VariationIdValue>(key: string, defaultVariationId: T, user?: User): Promise<VariationIdTypeOf<T>> {
         this.options.logger.debug("getVariationIdAsync() called.");
 
-        let variationId: any, evaluationDetails: IEvaluationDetails;
+        let variationId: VariationIdTypeOf<T>, evaluationDetails: IEvaluationDetails;
         let remoteConfig: ProjectConfig | null = null;
         user ??= this.defaultUser;
         try {
             let settings: { [name: string]: Setting } | null;
             [settings, remoteConfig] = await this.getSettingsAsync();
             evaluationDetails = evaluateVariationId(this.evaluator, settings, key, defaultVariationId, user, remoteConfig, this.options.logger);
-            variationId = evaluationDetails.variationId;
+            variationId = evaluationDetails.variationId as VariationIdTypeOf<T>;
         }
         catch (err) {
             this.options.logger.error("Error occurred in getVariationIdAsync().", err);
             evaluationDetails = evaluationDetailsFromDefaultVariationId(key, defaultVariationId, getTimestampAsDate(remoteConfig), user, errorToString(err), err);
-            variationId = defaultVariationId;
+            variationId = defaultVariationId as VariationIdTypeOf<T>;
         }
 
         this.options.hooks.emit("flagEvaluated", evaluationDetails);
@@ -442,7 +442,7 @@ export class ConfigCatClient implements IConfigCatClient {
             if (errors?.length) {
                 throw typeof AggregateError !== "undefined" ? new AggregateError(errors) : errors.pop();
             }
-            result = evaluationDetailsArray.map(details => details.variationId);
+            result = evaluationDetailsArray.filter(details => details !== null && details !== void 0).map(details => details.variationId!);
         }
         catch (err) {
             this.options.logger.error("Error occurred in getAllVariationIdsAsync().", err);
@@ -669,7 +669,7 @@ export class ConfigCatClient implements IConfigCatClient {
     }
 }
 
-export class SettingKeyValue<TValue = any> {
+export class SettingKeyValue<TValue = SettingValue> {
     constructor(
         public settingKey: string,
         public settingValue: TValue)

--- a/src/RolloutEvaluator.ts
+++ b/src/RolloutEvaluator.ts
@@ -617,7 +617,7 @@ export function evaluate<T extends SettingValue>(evaluator: IRolloutEvaluator, s
     const evaluationDetails = evaluator.Evaluate(setting, key, defaultValue, user, remoteConfig);
 
     if (defaultValue !== null && defaultValue !== void 0 && typeof defaultValue !== typeof evaluationDetails.value) {
-        throw new Error(`The type of a setting must match the type of the setting's default value.\nSetting's type was ${typeof defaultValue} but the default value's type was ${typeof evaluationDetails.value}.\nPlease use a default value which corresponds to the setting type.`);
+        throw new Error(`The type of a setting must match the type of the given default value.\nThe setting's type was ${typeof defaultValue}, the given default value's type was ${typeof evaluationDetails.value}.\nPlease pass a corresponding default value type.`);
     }
 
     return evaluationDetails as IEvaluationDetails<SettingTypeOf<T>>;
@@ -706,7 +706,7 @@ export function ensureAllowedDefaultValue(value: SettingValue) {
         return;
     }
 
-    throw new Error("Default value is only allowed to be a boolean, number, string, null or undefined value.");
+    throw new Error("The default value must be boolean, number, string, null or undefined.");
 }
 
 function keysToString(settings: { [name: string]: Setting }) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ export type { IConfigCatClient }
 
 export { SettingKeyValue } from "./ConfigCatClient";
 
-export type { IEvaluationDetails } from "./RolloutEvaluator";
+export type { IEvaluationDetails, SettingTypeOf, SettingValue, VariationIdTypeOf, VariationIdValue } from "./RolloutEvaluator";
 
 export { User } from "./RolloutEvaluator";
 

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -365,7 +365,7 @@ describe("ConfigCatClient", () => {
       // Arrange
   
       const key = "debug";
-      const defaultValue = false;
+      const defaultValue = "N/A";
       const timestamp = new Date().getTime();
   
       const configFetcherClass = FakeConfigFetcherWithRules;
@@ -412,7 +412,7 @@ describe("ConfigCatClient", () => {
       // Arrange
   
       const key = "string25Cat25Dog25Falcon25Horse";
-      const defaultValue = false;
+      const defaultValue = "N/A";
       const timestamp = new Date().getTime();
   
       const configFetcherClass = FakeConfigFetcherWithPercantageRules;
@@ -1270,7 +1270,7 @@ describe("ConfigCatClient", () => {
       var evaluationDetails: IEvaluationDetails[] = [];
       for (let key of keys)
       {
-          evaluationDetails.push(await client.getValueDetailsAsync(key, ""));
+          evaluationDetails.push(await client.getValueDetailsAsync(key, false));
       }
 
       assert.equal(evaluationDetails.length, flagEvaluatedEvents.length);


### PR DESCRIPTION
### Describe the purpose of your pull request

As pointed out by https://github.com/configcat/common-js/pull/71, the `IConfigCatClient` interface is not optimal concerning the `getValue`/`getValueAsync`, `getValueDetails`/`getValueDetailsAsync` methods. These methods take a default value and return `any`, so users get no help from the TS compiler at all: they can use mismatching types without a compile-time or run-time warning. For example
```js
let value: boolean = await client.getValueAsync("KEY", 1);
```
compiles without errors but the actual (run-time) type of the variable `value` can be totally different from its compile-time type (`boolean`) because
1. when the key doesn't exist, `1` is returned which is not a `boolean` value but a `number`.
2. when the key exists, nothing guarantees that the type of the evaluated setting is actually `boolean`. Currently we don't have such checks in place which would enforce that the default value and the evaluated value have the same type.

https://github.com/configcat/common-js/pull/71 suggests making the methods in question generic, which would solve the first problem as in that case TS compiler would enforce that the types of the default value and the return value match:
```js
let value: boolean = await client.getValueAsync("KEY", 1); // Compile error
let value2: boolean = await client.getValueAsync("KEY", false); // OK
```

However, this doesn't address the second problem as it still not guarantees that `value2` holds a `boolean` value in all cases. When the setting exists, the evaluated value can be e.g. a `string`. In this regard this API may be even worse as it suggests to the user that the assignment is type-safe and variable `value` must be a `boolean`.

This PR aims to address both of the problems:
- [Makes the signatures of these methods generic](https://github.com/configcat/common-js/pull/73/commits/f4a821c1bf9173c511304ec7893a762e23176877#diff-099ddaac3d178ac178a4187aeb32c9c4215da7f98982a88ed31125a4c6eac6c0R21-R32) so TS compiler enforces that the types of default value and return value match.
- [Disallows default values other than `boolean`, `number`, `string`, `null` and `undefined`](https://github.com/configcat/common-js/pull/73/commits/f4a821c1bf9173c511304ec7893a762e23176877#diff-099ddaac3d178ac178a4187aeb32c9c4215da7f98982a88ed31125a4c6eac6c0R315). (This prevents users from passing non-sense default values to these methods. We may relax this check by using a warning instead if we want to reduce the possibility of breaking the behavior of existing user code.)
- [Requires that the types of default value and evaluated setting value match when default value is not `null` and `undefined`](https://github.com/configcat/common-js/pull/73/commits/f4a821c1bf9173c511304ec7893a762e23176877#diff-30d7cdce233fb6777b0a0a686b7c31f2c426d0530cfe112dee0ee8ff10b9ce8cR611-R613). (This ensures that TS compiler's type check is enforced at run-time, that is, the run-time type of the return value corresponds to its reported compile-time type under all circumstances.  We may relax this check by using a warning instead if we want to reduce the possibility of breaking the behavior of existing user code.)

Examples:

```js
const client = getClient("SDK-KEY", PollingMode.AutoPoll);

const a1 = await client.getValueAsync("KEY", false); // Variable's inferred compile-time type: boolean / Run-time type: boolean (enforced by checks)
const a2 = await client.getValueAsync("KEY", null); // Variable's inferred compile-time type: string | number | boolean | null / Run-time type: null (if KEY is not present) | boolean | number | string (depending on the actual setting value)
const a3 = await client.getValueAsync("KEY", undefined); // Variable's inferred compile-time type: string | number | boolean | undefined / Run-time type: undefined (if KEY is not present) | boolean | number | string (depending on the actual setting value)

const b1 = await client.getValueAsync<boolean>("KEY", false); // Variable's inferred compile-time type: boolean / Run-time type: boolean (enforced by checks)
const b2 = await client.getValueAsync<boolean>("KEY", null); // Compile error: Argument of type 'null' is not assignable to parameter of type 'boolean'.
const b3 = await client.getValueAsync<boolean>("KEY", undefined); // Compile error: Argument of type 'undefined' is not assignable to parameter of type 'boolean'.

const c1 = await client.getValueAsync<boolean | null>("KEY", false); // Variable's inferred compile-time type: string | number | boolean | null / Run-time type: boolean (enforced by checks)
const c2 = await client.getValueAsync<boolean | null>("KEY", null); // Variable's inferred compile-time type: string | number | boolean | null / Run-time type: null (if KEY is not present) | boolean | number | string (depending on the actual setting value)
const c3 = await client.getValueAsync<boolean | null>("KEY", undefined); // Compile error: Argument of type 'undefined' is not assignable to parameter of type 'boolean | null'.

const d1 = await client.getValueAsync<boolean | undefined>("KEY", false); // Variable's inferred compile-time type: string | number | boolean | undefined / Run-time type: boolean (enforced by checks)
const d2 = await client.getValueAsync<boolean | undefined>("KEY", null); // Compile error: Argument of type 'null' is not assignable to parameter of type 'boolean | undefined'.
const d3 = await client.getValueAsync<boolean | undefined>("KEY", undefined); // Variable's inferred compile-time type: string | number | boolean | undefined / Run-time type: undefined (if KEY is not present) | boolean | number | string (depending on the actual setting value)

const e1 = await client.getValueAsync<boolean | string>("KEY", false); // Variable's inferred compile-time type: string | boolean / Run-time type: boolean (enforced by checks)
const e2 = await client.getValueAsync<boolean | string>("KEY", null); // Compile error: Argument of type 'null' is not assignable to parameter of type 'string | boolean'.
const e3 = await client.getValueAsync<boolean | string>("KEY", undefined); // Compile error: Argument of type 'undefined' is not assignable to parameter of type 'string | boolean'.

const f1 = await client.getValueAsync<any>("KEY", false); // Variable's inferred compile-time type: any / Run-time type: boolean (enforced by checks)
const f2 = await client.getValueAsync<any>("KEY", null); // Variable's inferred compile-time type: any / null (if KEY is not present) | boolean | number | string (depending on the actual setting value)
const f3 = await client.getValueAsync<any>("KEY", undefined); // Variable's inferred compile-time type: any / Run-time type: undefined (if KEY is not present) | boolean | number | string (depending on the actual setting value)

const err1: boolean = await client.getValueAsync("KEY", 123); // Compile error: Type 'number' is not assignable to type 'boolean'.
const err2: boolean = await client.getValueAsync("KEY", null); // Compile error: Type 'string | number | boolean | null' is not assignable to type 'boolean'. Type 'null' is not assignable to type 'boolean'.
const err3: boolean = await client.getValueAsync<boolean | null>("KEY", false); // Compile error: Type 'string | number | boolean | null' is not assignable to type 'boolean'.
const err4: boolean = await client.getValueAsync<boolean | null>("KEY", null); // Compile error: Type 'string | number | boolean | null' is not assignable to type 'boolean'.
```

Cases `c1` and `d1` are not optimal as the return type could be simply `boolean`. However, I don't know of a way to express this with TS type system. It may be possible but probably it'd be pretty complicated, so I think we can ignore this because these are pretty marginal cases anyway.

The PR also corrects the signature of the `getVariationId`/`getVariationIdAsync` and the behavior of `getAllVariationIds`/ `getAllVariationIdsAsync` methods.

**These changes are non-negligible breaking changes**, so I'm pinging @configcat/ux-qa-team to also review this.

IMO it's ok to make these changes because
* they only break incorrect user code (possible symptoms: users' code may not compile in case they use TypeScript; errors may be logged at run-time and user may experience changed behavior in case the types of default value and actual value mismatch)
* they help users to detect bugs in their code which could remain hidden otherwise
* they make the behavior more consistent with other SDKs
* the upcoming release is a major version anyway

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
