### PR TITLE
Improve "is (not) one of (sensitive)" performance by only hashing value once

### DIFF
--- a/src/RolloutEvaluator.ts
+++ b/src/RolloutEvaluator.ts
@@ -281,12 +281,13 @@ export class RolloutEvaluator implements IRolloutEvaluator {
             log += "no match";
 
             break;
-          case 16: // is one of (sensitive)
+          case 16: { // is one of (sensitive)
             const values: string[] = comparisonValue.split(",");
+            const hashedComparisonAttribute: string = sha1(comparisonAttribute);
 
             for (let ci = 0; ci < values.length; ci++) {
 
-              if (values[ci].trim() === sha1(comparisonAttribute)) {
+              if (values[ci].trim() === hashedComparisonAttribute) {
                 log += "MATCH";
                 eLog.opAppendLine(log);
 
@@ -297,10 +298,13 @@ export class RolloutEvaluator implements IRolloutEvaluator {
             log += "no match";
 
             break;
+          }
 
-          case 17: // is not one of (sensitive)
+          case 17: { // is not one of (sensitive)
+            const hashedComparisonAttribute: string = sha1(comparisonAttribute);
+
             if (!comparisonValue.split(",").some(e => {
-              if (e.trim() === sha1(comparisonAttribute)) {
+              if (e.trim() === hashedComparisonAttribute) {
                 return true;
               }
 
@@ -315,6 +319,8 @@ export class RolloutEvaluator implements IRolloutEvaluator {
             log += "no match";
 
             break;
+          }
+
           default:
             break;
         }


### PR DESCRIPTION
### Describe the purpose of your pull request

Last week my company added several thousand user IDs to a `is one of (hashed)` rule (since it seemed simpler than doing a mass edit to our db and using a custom attribute) and the CPU on our API server spiked. Looking through this SDK's source code I discovered there's optimizations that can be made to this rule type.

### Related issues (only if applicable)

N/A

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
  Not sure how I'd add a new automated test that tests timing that would be consistent among different devices, but I added a screenshot of the speed improvement on my own machine.
- [x] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
  Only tested on macOS but since I just moved a line up, platform should be irrelevant.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).


Test performed against this rule set. There are 1000 IDs per line, for a total of 4000 IDs, under a "worst-case-scenario" where the target user ID does not exist in the list so it has to check every value.
![image](https://user-images.githubusercontent.com/899916/224882519-62c1da58-2faa-4ac8-8336-d5cfb73f0e47.png)

Test Code:
```ts
const user = { identifier: "foo" };

const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcherWithThousandsOfIDs(), sdkType: "common", sdkVersion: "1.0.0" };
const client: IConfigCatClient = configcatClient.createClientWithAutoPoll("APIKEY", configCatKernel, { logger: configcatClient.createConsoleLogger(configcatClient.LogLevel.Error) });

let start = new Date();
console.log(await client.getValueAsync("testFeature", false, user));
console.log(`Time to evaluate one user: ${new Date().getTime() - start.getTime()}ms`);

start = new Date();
const valuesPromises = [];
for (let i = 0; i < 100; i++) {
  valuesPromises.push(client.getValueAsync("testFeature", false, user));
}

await Promise.all(valuesPromises);
console.log(`Time to evaluate 100 concurrent users: ${new Date().getTime() - start.getTime()}ms`);
```

Before (top) / After (bottom)
![image](https://user-images.githubusercontent.com/899916/224883155-38b1ba01-5f1e-4e74-9cb2-ced85db9f715.png)
