### PR TITLE
Remove deprecated code

### DIFF
--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -103,11 +103,6 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
     this.signalInitialization();
   }
 
-  protected onConfigChanged(newConfig: ProjectConfig): void {
-    super.onConfigChanged(newConfig);
-    this.options.configChanged();
-  }
-
   protected setOnlineCore(): void {
     this.startRefreshWorker(this.options.pollIntervalSeconds * 1000);
   }

--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -56,10 +56,10 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
   }
 
   async getConfig(): Promise<ProjectConfig | null> {
-    this.options.logger.logDebug("AutoPollConfigService.getConfig() called.");
+    this.options.logger.debug("AutoPollConfigService.getConfig() called.");
 
     function logSuccess(logger: LoggerWrapper) {
-      logger.logDebug("AutoPollConfigService.getConfig() - returning value from cache.");
+      logger.debug("AutoPollConfigService.getConfig() - returning value from cache.");
     }
 
     let cacheConfig: ProjectConfig | null = null;
@@ -70,7 +70,7 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
         return cacheConfig;
       }
 
-      this.options.logger.logDebug("AutoPollConfigService.getConfig() - cache is empty or expired, waiting for initialization.");
+      this.options.logger.debug("AutoPollConfigService.getConfig() - cache is empty or expired, waiting for initialization.");
       await this.waitForInitializationAsync();
     }
 
@@ -79,19 +79,19 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
       logSuccess(this.options.logger);
     }
     else {
-      this.options.logger.logDebug("AutoPollConfigService.getConfig() - cache is empty or expired.");
+      this.options.logger.debug("AutoPollConfigService.getConfig() - cache is empty or expired.");
     }
 
     return cacheConfig;
   }
 
   refreshConfigAsync(): Promise<[RefreshResult, ProjectConfig | null]> {
-    this.options.logger.logDebug("AutoPollConfigService.refreshConfigAsync() called.");
+    this.options.logger.debug("AutoPollConfigService.refreshConfigAsync() called.");
     return super.refreshConfigAsync();
   }
 
   dispose(): void {
-    this.options.logger.logDebug("AutoPollConfigService.dispose() called.");
+    this.options.logger.debug("AutoPollConfigService.dispose() called.");
     super.dispose();
     if (this.timerId) {
       this.stopRefreshWorker();
@@ -112,7 +112,7 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
   }
 
   private async startRefreshWorker(delayMs: number) {
-    this.options.logger.logDebug("AutoPollConfigService.startRefreshWorker() called.");
+    this.options.logger.debug("AutoPollConfigService.startRefreshWorker() called.");
 
     const latestConfig = await this.options.cache.get(this.options.getCacheKey());
     if (ProjectConfig.isExpired(latestConfig, this.options.pollIntervalSeconds * 1000)) {
@@ -130,29 +130,29 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
       this.signalInitialization();
     }
 
-    this.options.logger.logDebug("AutoPollConfigService.startRefreshWorker() - calling refreshWorkerLogic()'s setTimeout.");
+    this.options.logger.debug("AutoPollConfigService.startRefreshWorker() - calling refreshWorkerLogic()'s setTimeout.");
     this.timerId = setTimeout(d => this.refreshWorkerLogic(d), delayMs, delayMs);
   }
 
   private stopRefreshWorker() {
-    this.options.logger.logDebug("AutoPollConfigService.stopRefreshWorker() - clearing setTimeout.");
+    this.options.logger.debug("AutoPollConfigService.stopRefreshWorker() - clearing setTimeout.");
     clearTimeout(this.timerId);
   }
 
   private async refreshWorkerLogic(delayMs: number) {
     if (this.disposed) {
-      this.options.logger.logDebug("AutoPollConfigService.refreshWorkerLogic() - called on a disposed client.");
+      this.options.logger.debug("AutoPollConfigService.refreshWorkerLogic() - called on a disposed client.");
       return;
     }
 
-    this.options.logger.logDebug("AutoPollConfigService.refreshWorkerLogic() - called.");
+    this.options.logger.debug("AutoPollConfigService.refreshWorkerLogic() - called.");
 
     if (!this.isOffline) {
       const latestConfig = await this.options.cache.get(this.options.getCacheKey());
       await this.refreshConfigCoreAsync(latestConfig);
     }
 
-    this.options.logger.logDebug("AutoPollConfigService.refreshWorkerLogic() - calling refreshWorkerLogic()'s setTimeout.");
+    this.options.logger.debug("AutoPollConfigService.refreshWorkerLogic() - calling refreshWorkerLogic()'s setTimeout.");
     this.timerId = setTimeout(d => this.refreshWorkerLogic(d), delayMs, delayMs);
   }
 }

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -167,7 +167,7 @@ export class ConfigCatClient implements IConfigCatClient {
 
     this.options = options;
 
-    this.options.logger.logDebug("Initializing ConfigCatClient. Options: " + JSON.stringify(this.options));
+    this.options.logger.debug("Initializing ConfigCatClient. Options: " + JSON.stringify(this.options));
 
     if (!configCatKernel) {
       throw new Error("Invalid 'configCatKernel' value");
@@ -202,7 +202,7 @@ export class ConfigCatClient implements IConfigCatClient {
   private static finalize(data: IFinalizationData) {
     // Safeguard against situations where user forgets to dispose of the client instance.
 
-    data.logger?.logDebug("finalize() called");
+    data.logger?.debug("finalize() called");
 
     if (data.cacheToken) {
       clientInstanceCache.remove(data.sdkKey, data.cacheToken);
@@ -212,7 +212,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   private static close(configService?: IConfigService, logger?: LoggerWrapper, hooks?: Hooks) {
-    logger?.logDebug("close() called");
+    logger?.debug("close() called");
 
     hooks?.tryDisconnect();
     configService?.dispose();
@@ -220,7 +220,7 @@ export class ConfigCatClient implements IConfigCatClient {
 
   dispose(): void {
     const options = this.options;
-    options.logger.logDebug("dispose() called");
+    options.logger.debug("dispose() called");
 
     if (this.cacheToken) {
       clientInstanceCache.remove(options.apiKey, this.cacheToken);
@@ -251,7 +251,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getValueAsync<T extends SettingValue>(key: string, defaultValue: T, user?: User): Promise<SettingTypeOf<T>> {
-    this.options.logger.logDebug("getValueAsync() called.");
+    this.options.logger.debug("getValueAsync() called.");
 
     let value: SettingTypeOf<T>, evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>;
     let remoteConfig: ProjectConfig | null = null;
@@ -274,7 +274,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getValueDetailsAsync<T extends SettingValue>(key: string, defaultValue: T, user?: User): Promise<IEvaluationDetails<SettingTypeOf<T>>> {
-    this.options.logger.logDebug("getValueDetailsAsync() called.");
+    this.options.logger.debug("getValueDetailsAsync() called.");
 
     let evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>;
     let remoteConfig: ProjectConfig | null = null;
@@ -295,7 +295,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getAllKeysAsync(): Promise<string[]> {
-    this.options.logger.logDebug("getAllKeysAsync() called.");
+    this.options.logger.debug("getAllKeysAsync() called.");
 
     const defaultReturnValue = "empty array";
     try {
@@ -312,7 +312,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getAllValuesAsync(user?: User): Promise<SettingKeyValue[]> {
-    this.options.logger.logDebug("getAllValuesAsync() called.");
+    this.options.logger.debug("getAllValuesAsync() called.");
 
     const defaultReturnValue = "empty array";
     let result: SettingKeyValue[], evaluationDetailsArray: IEvaluationDetails[];
@@ -340,7 +340,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getAllValueDetailsAsync(user?: User): Promise<IEvaluationDetails[]> {
-    this.options.logger.logDebug("getAllValueDetailsAsync() called.");
+    this.options.logger.debug("getAllValueDetailsAsync() called.");
 
     const defaultReturnValue = "empty array";
     let evaluationDetailsArray: IEvaluationDetails[];
@@ -366,7 +366,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async getKeyAndValueAsync(variationId: string): Promise<SettingKeyValue | null> {
-    this.options.logger.logDebug("getKeyAndValueAsync() called.");
+    this.options.logger.debug("getKeyAndValueAsync() called.");
 
     const defaultReturnValue = "null";
     try {
@@ -411,7 +411,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   async forceRefreshAsync(): Promise<RefreshResult> {
-    this.options.logger.logDebug("forceRefreshAsync() called.");
+    this.options.logger.debug("forceRefreshAsync() called.");
 
     if (this.configService) {
       try {
@@ -454,7 +454,7 @@ export class ConfigCatClient implements IConfigCatClient {
   }
 
   private async getSettingsAsync(): Promise<SettingsWithRemoteConfig> {
-    this.options.logger.logDebug("getSettingsAsync() called.");
+    this.options.logger.debug("getSettingsAsync() called.");
 
     const getRemoteConfigAsync: () => Promise<SettingsWithRemoteConfig> = async () => {
       const config = await this.configService?.getConfig();

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -55,8 +55,6 @@ export interface IAutoPollOptions extends IOptions {
   pollIntervalSeconds?: number;
 
   maxInitWaitTimeSeconds?: number;
-
-  configChanged?: () => void;
 }
 
 export interface IManualPollOptions extends IOptions {
@@ -188,11 +186,6 @@ export class AutoPollOptions extends OptionsBase implements IAutoPollOptions {
   /** The client's poll interval in seconds. Default: 60 seconds. */
   pollIntervalSeconds: number = 60;
 
-  /** You can subscribe to configuration changes with this callback.
-   * @deprecated This property is obsolete and will be removed from the public API in a future major version. Please use the 'options.setupHooks = hooks => hooks.on("configChanged", ...)' format instead.
-   */
-  configChanged: () => void = () => { };
-
   /** Maximum waiting time between the client initialization and the first config acquisition in seconds. */
   maxInitWaitTimeSeconds: number = 5;
 
@@ -204,10 +197,6 @@ export class AutoPollOptions extends OptionsBase implements IAutoPollOptions {
 
       if (options.pollIntervalSeconds !== void 0 && options.pollIntervalSeconds !== null) {
         this.pollIntervalSeconds = options.pollIntervalSeconds;
-      }
-
-      if (options.configChanged) {
-        this.configChanged = options.configChanged;
       }
 
       if (options.maxInitWaitTimeSeconds !== void 0 && options.maxInitWaitTimeSeconds !== null) {

--- a/src/ConfigCatLogger.ts
+++ b/src/ConfigCatLogger.ts
@@ -60,9 +60,8 @@ export interface IConfigCatLogger {
    * @param eventId Event identifier.
    * @param message Message.
    * @param exception The exception object related to the message (if any).
-   * @remarks Later, when the deprecated methods are removed, this method will be changed to required and will be renamed to 'log'.
    */
-  logEvent(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): void;
+  log(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): void;
 }
 
 export class LoggerWrapper implements IConfigCatLogger {
@@ -80,9 +79,9 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   /** @inheritdoc */
-  logEvent(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): LogMessage {
+  log(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): LogMessage {
     if (this.isLogLevelEnabled(level)) {
-      this.logger.logEvent(level, eventId, message, exception);
+      this.logger.log(level, eventId, message, exception);
     }
 
     if (level === LogLevel.Error) {
@@ -95,21 +94,21 @@ export class LoggerWrapper implements IConfigCatLogger {
   /**
    * Shorthand method for `logger.logEvent(LogLevel.Debug, 0, message);`
    * */
-  logDebug(message: string): void {
-    this.logEvent(LogLevel.Debug, 0, message);
+  debug(message: string): void {
+    this.log(LogLevel.Debug, 0, message);
   }
 
   /* Common error messages (1000-1999) */
 
   configJsonIsNotPresent(defaultReturnValue: string): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1000,
       `Config JSON is not present. Returning ${defaultReturnValue}.`
     );
   }
 
   configJsonIsNotPresentSingle(key: string, defaultParamName: string, defaultParamValue: unknown): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1000,
       FormattableLogMessage.from(
         "KEY", "DEFAULT_PARAM_NAME", "DEFAULT_PARAM_VALUE"
@@ -118,7 +117,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   settingEvaluationFailedDueToMissingKey(key: string, defaultParamName: string, defaultParamValue: unknown, availableKeys: string): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1001,
       FormattableLogMessage.from(
         "KEY", "DEFAULT_PARAM_NAME", "DEFAULT_PARAM_VALUE", "AVAILABLE_KEYS"
@@ -127,7 +126,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   settingEvaluationError(methodName: string, defaultReturnValue: string, ex: any): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1002,
       new FormattableLogMessage(["Error occurred in the `", `\` method. Returning ${defaultReturnValue}.`], ["METHOD_NAME"], [methodName]),
       ex
@@ -135,7 +134,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   settingEvaluationErrorSingle(methodName: string, key: string, defaultParamName: string, defaultParamValue: unknown, ex: any): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1002,
       FormattableLogMessage.from(
         "METHOD_NAME", "KEY", "DEFAULT_PARAM_NAME", "DEFAULT_PARAM_VALUE",
@@ -145,7 +144,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   forceRefreshError(methodName: string, ex: any): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1003,
       FormattableLogMessage.from(
         "METHOD_NAME"
@@ -155,14 +154,14 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   fetchFailedDueToInvalidSdkKey(): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1100,
       "Your SDK Key seems to be wrong. You can find the valid SDK Key at https://app.configcat.com/sdkkey"
     );
   }
 
   fetchFailedDueToUnexpectedHttpResponse(statusCode: number, reasonPhrase: string): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1101,
       FormattableLogMessage.from(
         "STATUS_CODE", "REASON_PHRASE"
@@ -171,7 +170,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   fetchFailedDueToRequestTimeout(timeoutMs: number, ex: any): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1102,
       FormattableLogMessage.from(
         "TIMEOUT"
@@ -180,7 +179,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   fetchFailedDueToUnexpectedError(ex: any): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1103,
       "Unexpected error occurred while trying to fetch config JSON.",
       ex
@@ -188,21 +187,21 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   fetchFailedDueToRedirectLoop(): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1104,
       "Redirection loop encountered while trying to fetch config JSON. Please contact us at https://configcat.com/support/"
     );
   }
 
   fetchReceived200WithInvalidBody(): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1105,
       "Fetching config JSON was successful but the HTTP response content was invalid."
     );
   }
 
   fetchReceived304WhenLocalCacheIsEmpty(statusCode: number, reasonPhrase: string): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 1106,
       FormattableLogMessage.from(
         "STATUS_CODE", "REASON_PHRASE"
@@ -213,7 +212,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   /* SDK-specific error messages (2000-2999) */
 
   settingForVariationIdIsNotPresent(variationId: string): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Error, 2011,
       FormattableLogMessage.from(
         "VARIATION_ID"
@@ -224,7 +223,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   /* Common warning messages (3000-3999) */
 
   clientIsAlreadyCreated(sdkKey: string): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Warn, 3000,
       FormattableLogMessage.from(
         "SDK_KEY"
@@ -233,7 +232,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   targetingIsNotPossible(key: string): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Warn, 3001,
       FormattableLogMessage.from(
         "KEY"
@@ -242,21 +241,21 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   dataGovernanceIsOutOfSync(): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Warn, 3002,
       "The `dataGovernance` parameter specified at the client initialization is not in sync with the preferences on the ConfigCat Dashboard. Read more: https://configcat.com/docs/advanced/data-governance/"
     );
   }
 
   configServiceCannotInitiateHttpCalls(): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Warn, 3200,
       "Client is in offline mode, it cannot initiate HTTP calls."
     );
   }
 
   configServiceMethodHasNoEffectDueToDisposedClient(methodName: string): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Warn, 3201,
       FormattableLogMessage.from(
         "METHOD_NAME"
@@ -265,7 +264,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   configServiceMethodHasNoEffectDueToOverrideBehavior(overrideBehavior: string, methodName: string): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Warn, 3202,
       FormattableLogMessage.from(
         "OVERRIDE_BEHAVIOR", "METHOD_NAME"
@@ -278,7 +277,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   /* Common info messages (5000-5999) */
 
   settingEvaluated(evaluateLog: object): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Info, 5000,
       FormattableLogMessage.from(
         "EVALUATE_LOG"
@@ -286,7 +285,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   }
 
   configServiceStatusChanged(status: string): LogMessage {
-    return this.logEvent(
+    return this.log(
       LogLevel.Info, 5200,
       FormattableLogMessage.from(
         "MODE"
@@ -308,7 +307,7 @@ export class ConfigCatConsoleLogger implements IConfigCatLogger {
   }
 
   /** @inheritdoc */
-  logEvent(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): void {
+  log(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): void {
     const [logMethod, levelString] =
       level === LogLevel.Debug ? [console.info, "DEBUG"] :
       level === LogLevel.Info ? [console.info, "INFO"] :

--- a/src/ConfigCatLogger.ts
+++ b/src/ConfigCatLogger.ts
@@ -55,31 +55,6 @@ export interface IConfigCatLogger {
   readonly level?: LogLevel;
 
   /**
-   * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please implement the logEvent() method instead.
-   */
-  debug?(message: string): void;
-
-  /**
-   * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please implement the logEvent() method instead.
-   */
-  log?(message: string): void;
-
-  /**
-   * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please implement the logEvent() method instead.
-   */
-  info?(message: string): void;
-
-  /**
-   * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please implement the logEvent() method instead.
-   */
-  warn?(message: string): void;
-
-  /**
-   * @deprecated This method is obsolete and will be removed from the public API in a future major version. Please implement the logEvent() method instead.
-   */
-  error?(message: string): void;
-
-  /**
    * Writes a message into the log.
    * @param level Level (event severity).
    * @param eventId Event identifier.
@@ -87,7 +62,7 @@ export interface IConfigCatLogger {
    * @param exception The exception object related to the message (if any).
    * @remarks Later, when the deprecated methods are removed, this method will be changed to required and will be renamed to 'log'.
    */
-  logEvent?(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): void;
+  logEvent(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): void;
 }
 
 export class LoggerWrapper implements IConfigCatLogger {
@@ -100,20 +75,6 @@ export class LoggerWrapper implements IConfigCatLogger {
     private readonly hooks?: Hooks) {
   }
 
-  debug: (message: string) => void = this.logDebug;
-
-  info(message: string): void {
-    this.logEvent(LogLevel.Info, 0, message);
-  }
-
-  warn(message: string): void {
-    this.logEvent(LogLevel.Warn, 0, message);
-  }
-
-  error(message: string, err?: any): void {
-    this.logEvent(LogLevel.Error, 0, message, err);
-  }
-
   private isLogLevelEnabled(logLevel: LogLevel): boolean {
     return this.level >= logLevel;
   }
@@ -121,27 +82,7 @@ export class LoggerWrapper implements IConfigCatLogger {
   /** @inheritdoc */
   logEvent(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): LogMessage {
     if (this.isLogLevelEnabled(level)) {
-      if (this.logger.logEvent) {
-        this.logger.logEvent(level, eventId, message, exception);
-      }
-      else {
-        switch (level) {
-          case LogLevel.Error:
-            this.logger.error?.(message.toString());
-            break;
-          case LogLevel.Warn:
-            this.logger.warn?.(message.toString());
-            break;
-          case LogLevel.Info:
-            this.logger.info?.(message.toString());
-            break;
-          case LogLevel.Debug:
-            this.logger.debug?.(message.toString());
-            break;
-          default:
-            break;
-        }
-      }
+      this.logger.logEvent(level, eventId, message, exception);
     }
 
     if (level === LogLevel.Error) {
@@ -364,31 +305,6 @@ export class ConfigCatConsoleLogger implements IConfigCatLogger {
    * Create an instance of ConfigCatConsoleLogger
    */
   constructor(public level = LogLevel.Warn) {
-  }
-
-  /** @inheritdoc */
-  log(message: string): void {
-    this.info(message);
-  }
-
-  /** @inheritdoc */
-  debug(message: string): void {
-    this.logEvent(LogLevel.Debug, 0, message);
-  }
-
-  /** @inheritdoc */
-  info(message: string): void {
-    this.logEvent(LogLevel.Info, 0, message);
-  }
-
-  /** @inheritdoc */
-  warn(message: string): void {
-    this.logEvent(LogLevel.Warn, 0, message);
-  }
-
-  /** @inheritdoc */
-  error(message: string): void {
-    this.logEvent(LogLevel.Error, 0, message);
   }
 
   /** @inheritdoc */

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -108,7 +108,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
   protected onConfigUpdated(newConfig: ProjectConfig): void { }
 
   protected onConfigChanged(newConfig: ProjectConfig): void {
-    this.options.logger.logDebug("config changed");
+    this.options.logger.debug("config changed");
     this.options.hooks.emit("configChanged", newConfig);
   }
 
@@ -125,7 +125,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
   private async fetchLogicAsync(lastConfig: ProjectConfig | null): Promise<[FetchResult, ProjectConfig | null]> {
     const options = this.options;
-    options.logger.logDebug("ConfigServiceBase.fetchLogicAsync() - called.");
+    options.logger.debug("ConfigServiceBase.fetchLogicAsync() - called.");
 
     let errorMessage: string;
     try {
@@ -135,32 +135,32 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
         case 200: // OK
           if (!configJson) {
             errorMessage = options.logger.fetchReceived200WithInvalidBody().toString();
-            options.logger.logDebug(`ConfigServiceBase.fetchLogicAsync(): ${response.statusCode} ${response.reasonPhrase} was received but the HTTP response content was invalid. Returning null.`);
+            options.logger.debug(`ConfigServiceBase.fetchLogicAsync(): ${response.statusCode} ${response.reasonPhrase} was received but the HTTP response content was invalid. Returning null.`);
             return [FetchResult.error(errorMessage), null];
           }
 
-          options.logger.logDebug("ConfigServiceBase.fetchLogicAsync(): fetch was successful. Returning new config.");
+          options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was successful. Returning new config.");
           return [FetchResult.success(response.body!, response.eTag!), new ProjectConfig(new Date().getTime(), configJson, response.eTag)];
 
         case 304: // Not Modified
           if (!lastConfig) {
             errorMessage = options.logger.fetchReceived304WhenLocalCacheIsEmpty(response.statusCode, response.reasonPhrase).toString();
-            options.logger.logDebug(`ConfigServiceBase.fetchLogicAsync(): ${response.statusCode} ${response.reasonPhrase} was received when no config is cached locally. Returning null.`);
+            options.logger.debug(`ConfigServiceBase.fetchLogicAsync(): ${response.statusCode} ${response.reasonPhrase} was received when no config is cached locally. Returning null.`);
             return [FetchResult.error(errorMessage), null];
           }
 
-          options.logger.logDebug("ConfigServiceBase.fetchLogicAsync(): content was not modified. Returning last config with updated timestamp.");
+          options.logger.debug("ConfigServiceBase.fetchLogicAsync(): content was not modified. Returning last config with updated timestamp.");
           return [FetchResult.notModified(), new ProjectConfig(new Date().getTime(), lastConfig.ConfigJSON, lastConfig.HttpETag)];
 
         case 403: // Forbidden
         case 404: // Not Found
           errorMessage = options.logger.fetchFailedDueToInvalidSdkKey().toString();
-          options.logger.logDebug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning last config (if any) with updated timestamp.");
+          options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning last config (if any) with updated timestamp.");
           return [FetchResult.error(errorMessage), lastConfig ? new ProjectConfig(new Date().getTime(), lastConfig.ConfigJSON, lastConfig.HttpETag) : null];
 
         default:
           errorMessage = options.logger.fetchFailedDueToUnexpectedHttpResponse(response.statusCode, response.reasonPhrase).toString();
-          options.logger.logDebug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning null.");
+          options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning null.");
           return [FetchResult.error(errorMessage), null];
       }
     }
@@ -169,17 +169,17 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
         ? options.logger.fetchFailedDueToRequestTimeout((err.args as FetchErrorCauses["timeout"])[0], err)
         : options.logger.fetchFailedDueToUnexpectedError(err)).toString();
 
-      options.logger.logDebug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning null.");
+      options.logger.debug("ConfigServiceBase.fetchLogicAsync(): fetch was unsuccessful. Returning null.");
       return [FetchResult.error(errorMessage, err), null];
     }
   }
 
   private async fetchRequestAsync(lastETag: string | null, maxRetryCount = 2): Promise<[IFetchResponse, any?]> {
     const options = this.options;
-    options.logger.logDebug("ConfigServiceBase.fetchRequestAsync() - called.");
+    options.logger.debug("ConfigServiceBase.fetchRequestAsync() - called.");
 
     for (let retryNumber = 0; ; retryNumber++) {
-      options.logger.logDebug(`ConfigServiceBase.fetchRequestAsync(): calling fetchLogic()${retryNumber > 0 ? `, retry ${retryNumber}/${maxRetryCount}` : ""}`);
+      options.logger.debug(`ConfigServiceBase.fetchRequestAsync(): calling fetchLogic()${retryNumber > 0 ? `, retry ${retryNumber}/${maxRetryCount}` : ""}`);
       const response = await this.configFetcher.fetchLogic(options, lastETag);
 
       if (response.statusCode !== 200) {
@@ -187,7 +187,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       }
 
       if (!response.body) {
-        options.logger.logDebug("ConfigServiceBase.fetchRequestAsync(): no response body.");
+        options.logger.debug("ConfigServiceBase.fetchRequestAsync(): no response body.");
         return [response];
       }
 
@@ -196,13 +196,13 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
         configJSON = JSON.parse(response.body);
       }
       catch {
-        options.logger.logDebug("ConfigServiceBase.fetchRequestAsync(): invalid response body.");
+        options.logger.debug("ConfigServiceBase.fetchRequestAsync(): invalid response body.");
         return [response];
       }
 
       const preferences = configJSON[ConfigFile.Preferences];
       if (!preferences) {
-        options.logger.logDebug("ConfigServiceBase.fetchRequestAsync(): preferences is empty.");
+        options.logger.debug("ConfigServiceBase.fetchRequestAsync(): preferences is empty.");
         return [response, configJSON];
       }
 
@@ -210,7 +210,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
       // If the base_url is the same as the last called one, just return the response.
       if (!baseUrl || baseUrl === options.baseUrl) {
-        options.logger.logDebug("ConfigServiceBase.fetchRequestAsync(): baseUrl OK.");
+        options.logger.debug("ConfigServiceBase.fetchRequestAsync(): baseUrl OK.");
         return [response, configJSON];
       }
 
@@ -219,7 +219,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
       // If the base_url is overridden, and the redirect parameter is not 2 (force),
       // the SDK should not redirect the calls and it just have to return the response.
       if (options.baseUrlOverriden && redirect !== 2) {
-        options.logger.logDebug("ConfigServiceBase.fetchRequestAsync(): options.baseUrlOverriden && redirect !== 2.");
+        options.logger.debug("ConfigServiceBase.fetchRequestAsync(): options.baseUrlOverriden && redirect !== 2.");
         return [response, configJSON];
       }
 

--- a/src/LazyLoadConfigService.ts
+++ b/src/LazyLoadConfigService.ts
@@ -19,10 +19,10 @@ export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> im
   }
 
   async getConfig(): Promise<ProjectConfig | null> {
-    this.options.logger.logDebug("LazyLoadConfigService.getConfig() called.");
+    this.options.logger.debug("LazyLoadConfigService.getConfig() called.");
 
     function logExpired(logger: LoggerWrapper, appendix = "") {
-      logger.logDebug(`LazyLoadConfigService.getConfig(): cache is empty or expired${appendix}.`);
+      logger.debug(`LazyLoadConfigService.getConfig(): cache is empty or expired${appendix}.`);
     }
 
     let config = await this.options.cache.get(this.options.getCacheKey());
@@ -38,12 +38,12 @@ export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> im
       return config;
     }
 
-    this.options.logger.logDebug("LazyLoadConfigService.getConfig(): cache is valid, returning from cache.");
+    this.options.logger.debug("LazyLoadConfigService.getConfig(): cache is valid, returning from cache.");
     return config;
   }
 
   refreshConfigAsync(): Promise<[RefreshResult, ProjectConfig | null]> {
-    this.options.logger.logDebug("LazyLoadConfigService.refreshConfigAsync() called.");
+    this.options.logger.debug("LazyLoadConfigService.refreshConfigAsync() called.");
     return super.refreshConfigAsync();
   }
 }

--- a/src/ManualPollConfigService.ts
+++ b/src/ManualPollConfigService.ts
@@ -15,12 +15,12 @@ export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions
 
   async getConfig(): Promise<ProjectConfig | null> {
 
-    this.options.logger.logDebug("ManualPollService.getConfig() called.");
+    this.options.logger.debug("ManualPollService.getConfig() called.");
     return await this.options.cache.get(this.options.getCacheKey());
   }
 
   refreshConfigAsync(): Promise<[RefreshResult, ProjectConfig | null]> {
-    this.options.logger.logDebug("ManualPollService.refreshConfigAsync() called.");
+    this.options.logger.debug("ManualPollService.refreshConfigAsync() called.");
     return super.refreshConfigAsync();
   }
 }

--- a/src/RolloutEvaluator.ts
+++ b/src/RolloutEvaluator.ts
@@ -86,7 +86,7 @@ export class RolloutEvaluator implements IRolloutEvaluator {
   }
 
   evaluate(setting: Setting, key: string, defaultValue: SettingValue, user: User | undefined, remoteConfig: ProjectConfig | null): IEvaluationDetails {
-    this.logger.logDebug("RolloutEvaluator.Evaluate() called.");
+    this.logger.debug("RolloutEvaluator.Evaluate() called.");
 
     const eLog: EvaluateLogger = new EvaluateLogger();
 
@@ -144,7 +144,7 @@ export class RolloutEvaluator implements IRolloutEvaluator {
 
   private evaluateRules(rolloutRules: RolloutRule[], user: User, eLog: EvaluateLogger): IEvaluateResult<RolloutRule> | null {
 
-    this.logger.logDebug("RolloutEvaluator.EvaluateRules() called.");
+    this.logger.debug("RolloutEvaluator.EvaluateRules() called.");
 
     if (rolloutRules && rolloutRules.length > 0) {
 
@@ -323,7 +323,7 @@ export class RolloutEvaluator implements IRolloutEvaluator {
   }
 
   private evaluatePercentageRules(rolloutPercentageItems: RolloutPercentageItem[], key: string, user: User): IEvaluateResult<RolloutPercentageItem> | null {
-    this.logger.logDebug("RolloutEvaluator.EvaluateVariations() called.");
+    this.logger.debug("RolloutEvaluator.EvaluateVariations() called.");
     if (rolloutPercentageItems && rolloutPercentageItems.length > 0) {
 
       const hashCandidate: string = key + ((user.identifier === null || user.identifier === void 0) ? "" : user.identifier);
@@ -349,7 +349,7 @@ export class RolloutEvaluator implements IRolloutEvaluator {
   }
 
   private evaluateNumber(v1: string, v2: string, comparator: number): boolean {
-    this.logger.logDebug("RolloutEvaluator.EvaluateNumber() called.");
+    this.logger.debug("RolloutEvaluator.EvaluateNumber() called.");
 
     let n1: number, n2: number;
 
@@ -388,7 +388,7 @@ export class RolloutEvaluator implements IRolloutEvaluator {
   }
 
   private evaluateSemver(v1: string, v2: string, comparator: number): boolean {
-    this.logger.logDebug("RolloutEvaluator.EvaluateSemver() called.");
+    this.logger.debug("RolloutEvaluator.EvaluateSemver() called.");
     if (semver.valid(v1) == null || v2 === void 0) {
       return false;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { IConfigCatClient, IConfigCatKernel } from "./ConfigCatClient";
 import { ConfigCatClient } from "./ConfigCatClient";
 import type { IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions, OptionsForPollingMode } from "./ConfigCatClientOptions";
-import { AutoPollOptions, LazyLoadOptions, ManualPollOptions, PollingMode } from "./ConfigCatClientOptions";
+import { PollingMode } from "./ConfigCatClientOptions";
 import type { IConfigCatLogger } from "./ConfigCatLogger";
 import { ConfigCatConsoleLogger, LogLevel } from "./ConfigCatLogger";
 import { setupPolyfills } from "./Polyfills";
@@ -27,36 +27,6 @@ export function getClient<TMode extends PollingMode>(sdkKey: string, pollingMode
  */
 export function disposeAllClients(): void {
   ConfigCatClient.disposeAll();
-}
-
-/**
- * Create an instance of ConfigCatClient and setup AutoPoll mode
- * @param {string} apiKey - ApiKey to access your configuration.
- * @param config - Configuration for autoPoll mode
- * @deprecated This function is obsolete and will be removed from the public API in a future major version. To obtain a ConfigCatClient instance with auto polling for a specific SDK Key, please use the 'getClient(sdkKey, PollingMode.AutoPoll, options, ...)' format.
- */
-export function createClientWithAutoPoll(apiKey: string, configCatKernel: IConfigCatKernel, options?: IAutoPollOptions): IConfigCatClient {
-  return new ConfigCatClient(new AutoPollOptions(apiKey, configCatKernel.sdkType, configCatKernel.sdkVersion, options, configCatKernel.cache, configCatKernel.eventEmitterFactory), configCatKernel);
-}
-
-/**
- * Create an instance of ConfigCatClient and setup ManualPoll mode
- * @param {string} apiKey - ApiKey to access your configuration.
- * @param config - Configuration for manualPoll mode
- * @deprecated This function is obsolete and will be removed from the public API in a future major version. To obtain a ConfigCatClient instance with manual polling for a specific SDK Key, please use the 'getClient(sdkKey, PollingMode.ManualPoll, options, ...)' format.
- */
-export function createClientWithManualPoll(apiKey: string, configCatKernel: IConfigCatKernel, options?: IManualPollOptions): IConfigCatClient {
-  return new ConfigCatClient(new ManualPollOptions(apiKey, configCatKernel.sdkType, configCatKernel.sdkVersion, options, configCatKernel.cache, configCatKernel.eventEmitterFactory), configCatKernel);
-}
-
-/**
- * Create an instance of ConfigCatClient and setup LazyLoad mode
- * @param {string} apiKey - ApiKey to access your configuration.
- * @param config - Configuration for lazyLoad mode
- * @deprecated This function is obsolete and will be removed from the public API in a future major version. To obtain a ConfigCatClient instance with lazy loading for a specific SDK Key, please use the 'getClient(sdkKey, PollingMode.LazyLoad, options, ...)' format.
- */
-export function createClientWithLazyLoad(apiKey: string, configCatKernel: IConfigCatKernel, options?: ILazyLoadingOptions): IConfigCatClient {
-  return new ConfigCatClient(new LazyLoadOptions(apiKey, configCatKernel.sdkType, configCatKernel.sdkVersion, options, configCatKernel.cache, configCatKernel.eventEmitterFactory), configCatKernel);
 }
 
 /**
@@ -112,7 +82,7 @@ export type { IConfigCatClient };
 
 export { SettingKeyValue } from "./ConfigCatClient";
 
-export type { IEvaluationDetails, SettingTypeOf, SettingValue, VariationIdTypeOf, VariationIdValue } from "./RolloutEvaluator";
+export type { IEvaluationDetails, SettingTypeOf, SettingValue, VariationIdValue } from "./RolloutEvaluator";
 
 export { User } from "./RolloutEvaluator";
 

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -333,7 +333,7 @@ class FakeCache implements ICache {
 export class FakeLogger implements IConfigCatLogger {
   level?: LogLevel | undefined;
 
-  logEvent(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): void {
+  log(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): void {
     /* Intentionally empty. */
   }
 }

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -79,12 +79,10 @@ describe("Options", () => {
   it("AutoPollOptions initialization With parameters works", () => {
     const fakeLogger: FakeLogger = new FakeLogger();
 
-    const configChanged = function() { };
     const options: AutoPollOptions = new AutoPollOptions(
       "APIKEY", "common", "1.0.0",
       {
         logger: fakeLogger,
-        configChanged: configChanged,
         pollIntervalSeconds: 59,
         requestTimeoutMs: 20,
         proxy: "http://fake-proxy.com:8080"
@@ -97,7 +95,6 @@ describe("Options", () => {
     assert.equal("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/a-1.0.0", options.getUrl());
     assert.equal(59, options.pollIntervalSeconds);
     assert.equal(20, options.requestTimeoutMs);
-    assert.equal(configChanged, options.configChanged);
     assert.equal("http://fake-proxy.com:8080", options.proxy);
   });
 
@@ -335,26 +332,6 @@ class FakeCache implements ICache {
 
 export class FakeLogger implements IConfigCatLogger {
   level?: LogLevel | undefined;
-
-  debug(message: string): void {
-    /* Intentionally empty. */
-  }
-
-  info(message: string): void {
-    /* Intentionally empty. */
-  }
-
-  warn(message: string): void {
-    /* Intentionally empty. */
-  }
-
-  log(message: string): void {
-    /* Intentionally empty. */
-  }
-
-  error(message: string): void {
-    /* Intentionally empty. */
-  }
 
   logEvent(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any): void {
     /* Intentionally empty. */

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -18,38 +18,6 @@ import { FakeCache, FakeConfigCatKernel, FakeConfigFetcher, FakeConfigFetcherBas
 import { allowEventLoop } from "./helpers/utils";
 
 describe("ConfigCatClient", () => {
-  it("Initialization With AutoPollOptions should create an instance, getValue works", (done) => {
-    const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcher(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-    assert.isDefined(client);
-
-    client.getValue("debug", false, function(value) {
-      assert.equal(true, value);
-
-      client.getValue("debug", false, function(value) {
-        assert.equal(true, value);
-
-        client.forceRefresh(function() {
-          client.getValue("debug", false, function(value) {
-            assert.equal(true, value);
-
-            client.getValue("debug", false, function(value) {
-              assert.equal(true, value);
-
-              client.getValue("NOT_EXISTS", false, function(value) {
-                assert.equal(false, value);
-
-                done();
-              }, new User("identifier"));
-
-            }, new User("identifier"));
-          });
-        });
-      }, new User("identifier"));
-    });
-  });
-
   it("Initialization With AutoPollOptions should create an instance, getValueAsync works", async () => {
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcher(), sdkType: "common", sdkVersion: "1.0.0" };
     const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
@@ -64,33 +32,6 @@ describe("ConfigCatClient", () => {
     assert.equal(false, await client.getValueAsync("NOT_EXISTS", false, new User("identifier")));
   });
 
-  it("Initialization With LazyLoadOptions should create an instance, getValue works", (done) => {
-
-    const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcher(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options: LazyLoadOptions = new LazyLoadOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-    assert.isDefined(client);
-
-    client.getValue("debug", false, function(value) {
-      assert.equal(true, value);
-
-      client.getValue("debug", false, function(value) {
-        assert.equal(true, value);
-
-        client.getValue("NOT_EXISTS", false, function(value) {
-          assert.equal(false, value);
-
-          client.forceRefresh(function() {
-            client.getValue("debug", false, function(value) {
-              assert.equal(true, value);
-              done();
-            }, new User("identifier"));
-          });
-        }, new User("identifier"));
-      }, new User("identifier"));
-    }, new User("identifier"));
-  });
-
   it("Initialization With LazyLoadOptions should create an instance, getValueAsync works", async () => {
 
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcher(), sdkType: "common", sdkVersion: "1.0.0" };
@@ -103,39 +44,6 @@ describe("ConfigCatClient", () => {
     assert.equal(false, await client.getValueAsync("NOT_EXISTS", false, new User("identifier")));
     await client.forceRefreshAsync();
     assert.equal(true, await client.getValueAsync("debug", false, new User("identifier")));
-  });
-
-  it("Initialization With ManualPollOptions should create an instance, getValue works", (done) => {
-
-    const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcher(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options: ManualPollOptions = new ManualPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-    assert.isDefined(client);
-
-    client.getValue("debug", false, function(value) {
-      assert.equal(false, value);
-
-      client.getValue("debug", false, function(value) {
-        assert.equal(false, value);
-
-        client.forceRefresh(function() {
-          client.getValue("debug", false, function(value) {
-            assert.equal(true, value);
-
-            client.getValue("debug", false, function(value) {
-              assert.equal(true, value);
-
-              client.getValue("NOT_EXISTS", false, function(value) {
-                assert.equal(false, value);
-
-                done();
-              }, new User("identifier"));
-            }, new User("identifier"));
-          });
-        });
-
-      }, new User("identifier"));
-    });
   });
 
   it("Initialization With ManualPollOptions should create an instance, getValueAsync works", async () => {
@@ -159,8 +67,8 @@ describe("ConfigCatClient", () => {
     const options: ManualPollOptions = new ManualPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
-    client.forceRefresh(() => {
-      client.getValue("debug", false, function(value) {
+    client.forceRefreshAsync().then(() => {
+      client.getValueAsync("debug", false).then(function(value) {
         assert.equal(true, value);
         done();
       });
@@ -174,7 +82,7 @@ describe("ConfigCatClient", () => {
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
 
-    client.getValue("debug", false, function(value) {
+    client.getValueAsync("debug", false).then(function(value) {
       assert.equal(true, value);
       done();
     });
@@ -187,21 +95,8 @@ describe("ConfigCatClient", () => {
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
     assert.isDefined(client);
 
-    client.getValue("debug", false, function(value) {
+    client.getValueAsync("debug", false).then(function(value) {
       assert.equal(false, value);
-      done();
-    });
-  });
-
-  it("getValue() works without userObject", (done) => {
-    const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcher(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-
-    assert.isDefined(client);
-
-    client.getValue("debug", false, function(value) {
-      assert.equal(value, true);
       done();
     });
   });
@@ -223,20 +118,6 @@ describe("ConfigCatClient", () => {
     assert.strictEqual(value, flagEvaluatedEvents[0].value);
   });
 
-  it("getAllKeys() works", (done) => {
-
-    const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcherWithTwoKeys(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-    assert.isDefined(client);
-    client.getAllKeys(function(keys) {
-      assert.equal(keys.length, 2);
-      assert.equal(keys[0], "debug");
-      assert.equal(keys[1], "debug2");
-      done();
-    });
-  });
-
   it("getAllKeysAsync() works", async () => {
 
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcherWithTwoKeys(), sdkType: "common", sdkVersion: "1.0.0" };
@@ -249,18 +130,6 @@ describe("ConfigCatClient", () => {
     assert.equal(keys[1], "debug2");
   });
 
-  it("getAllKeys() works - without config", (done) => {
-
-    const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcherWithNullNewConfig(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null, maxInitWaitTimeSeconds: 0 }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-    assert.isDefined(client);
-    client.getAllKeys(function(keys) {
-      assert.equal(keys.length, 0);
-      done();
-    });
-  });
-
   it("getAllKeysAsync() works - without config", async () => {
 
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcherWithNullNewConfig(), sdkType: "common", sdkVersion: "1.0.0" };
@@ -271,379 +140,352 @@ describe("ConfigCatClient", () => {
     assert.equal(keys.length, 0);
   });
 
-  for (const isAsync of [false, true]) {
-    it(`getValueDetails${isAsync ? "Async" : ""}() should return correct result when setting is not available`, async () => {
+  it("getValueDetailsAsync() should return correct result when setting is not available", async () => {
 
-      // Arrange
+    // Arrange
 
-      const key = "notexists";
-      const defaultValue = false;
-      const timestamp = new Date().getTime();
+    const key = "notexists";
+    const defaultValue = false;
+    const timestamp = new Date().getTime();
 
-      const configFetcherClass = FakeConfigFetcherWithTwoKeys;
-      const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
-      const configCache = new FakeCache(cachedPc);
-      const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-      const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
-      const client = new ConfigCatClient(options, configCatKernel);
+    const configFetcherClass = FakeConfigFetcherWithTwoKeys;
+    const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
+    const configCache = new FakeCache(cachedPc);
+    const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
+    const client = new ConfigCatClient(options, configCatKernel);
 
-      const user = new User("a@configcat.com");
+    const user = new User("a@configcat.com");
 
-      const flagEvaluatedEvents: IEvaluationDetails[] = [];
-      client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
+    const flagEvaluatedEvents: IEvaluationDetails[] = [];
+    client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
 
-      // Act
+    // Act
 
-      const actual = await (isAsync
-        ? client.getValueDetailsAsync(key, defaultValue, user)
-        : new Promise<IEvaluationDetails>(resolve => client.getValueDetails(key, defaultValue, resolve, user))
-      );
+    const actual = await client.getValueDetailsAsync(key, defaultValue, user);
 
-      // Assert
+    // Assert
 
-      assert.strictEqual(key, actual.key);
-      assert.strictEqual(defaultValue, actual.value);
-      assert.isTrue(actual.isDefaultValue);
-      assert.isUndefined(actual.variationId);
-      assert.strictEqual(cachedPc.Timestamp, actual.fetchTime?.getTime());
-      assert.strictEqual(user, actual.user);
-      assert.isDefined(actual.errorMessage);
-      assert.isUndefined(actual.errorException);
-      assert.isUndefined(actual.matchedEvaluationRule);
-      assert.isUndefined(actual.matchedEvaluationPercentageRule);
+    assert.strictEqual(key, actual.key);
+    assert.strictEqual(defaultValue, actual.value);
+    assert.isTrue(actual.isDefaultValue);
+    assert.isUndefined(actual.variationId);
+    assert.strictEqual(cachedPc.Timestamp, actual.fetchTime?.getTime());
+    assert.strictEqual(user, actual.user);
+    assert.isDefined(actual.errorMessage);
+    assert.isUndefined(actual.errorException);
+    assert.isUndefined(actual.matchedEvaluationRule);
+    assert.isUndefined(actual.matchedEvaluationPercentageRule);
 
-      assert.equal(1, flagEvaluatedEvents.length);
-      assert.strictEqual(actual, flagEvaluatedEvents[0]);
-    });
+    assert.equal(1, flagEvaluatedEvents.length);
+    assert.strictEqual(actual, flagEvaluatedEvents[0]);
+  });
 
-    it(`getValueDetails${isAsync ? "Async" : ""}() should return correct result when setting is available but no rule applies`, async () => {
+  it("getValueDetailsAsync() should return correct result when setting is available but no rule applies", async () => {
 
-      // Arrange
+    // Arrange
 
-      const key = "debug";
-      const defaultValue = false;
-      const timestamp = new Date().getTime();
+    const key = "debug";
+    const defaultValue = false;
+    const timestamp = new Date().getTime();
 
-      const configFetcherClass = FakeConfigFetcherWithTwoKeys;
-      const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
-      const configCache = new FakeCache(cachedPc);
-      const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-      const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
-      const client = new ConfigCatClient(options, configCatKernel);
+    const configFetcherClass = FakeConfigFetcherWithTwoKeys;
+    const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
+    const configCache = new FakeCache(cachedPc);
+    const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
+    const client = new ConfigCatClient(options, configCatKernel);
 
-      const user = new User("a@configcat.com");
+    const user = new User("a@configcat.com");
 
-      const flagEvaluatedEvents: IEvaluationDetails[] = [];
-      client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
+    const flagEvaluatedEvents: IEvaluationDetails[] = [];
+    client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
 
-      // Act
+    // Act
 
-      const actual = await (isAsync
-        ? client.getValueDetailsAsync(key, defaultValue, user)
-        : new Promise<IEvaluationDetails>(resolve => client.getValueDetails(key, defaultValue, resolve, user))
-      );
+    const actual = await client.getValueDetailsAsync(key, defaultValue, user);
 
-      // Assert
+    // Assert
 
-      assert.strictEqual(key, actual.key);
-      assert.strictEqual(true, actual.value);
-      assert.isFalse(actual.isDefaultValue);
-      assert.strictEqual("abcdefgh", actual.variationId);
-      assert.strictEqual(cachedPc.Timestamp, actual.fetchTime?.getTime());
-      assert.strictEqual(user, actual.user);
-      assert.isUndefined(actual.errorMessage);
-      assert.isUndefined(actual.errorException);
-      assert.isUndefined(actual.matchedEvaluationRule);
-      assert.isUndefined(actual.matchedEvaluationPercentageRule);
+    assert.strictEqual(key, actual.key);
+    assert.strictEqual(true, actual.value);
+    assert.isFalse(actual.isDefaultValue);
+    assert.strictEqual("abcdefgh", actual.variationId);
+    assert.strictEqual(cachedPc.Timestamp, actual.fetchTime?.getTime());
+    assert.strictEqual(user, actual.user);
+    assert.isUndefined(actual.errorMessage);
+    assert.isUndefined(actual.errorException);
+    assert.isUndefined(actual.matchedEvaluationRule);
+    assert.isUndefined(actual.matchedEvaluationPercentageRule);
 
-      assert.equal(1, flagEvaluatedEvents.length);
-      assert.strictEqual(actual, flagEvaluatedEvents[0]);
-    });
+    assert.equal(1, flagEvaluatedEvents.length);
+    assert.strictEqual(actual, flagEvaluatedEvents[0]);
+  });
 
-    it(`getValueDetails${isAsync ? "Async" : ""}() should return correct result when setting is available and a comparison-based rule applies`, async () => {
+  it("getValueDetailsAsync() should return correct result when setting is available and a comparison-based rule applies", async () => {
 
-      // Arrange
+    // Arrange
 
-      const key = "debug";
-      const defaultValue = "N/A";
-      const timestamp = new Date().getTime();
+    const key = "debug";
+    const defaultValue = "N/A";
+    const timestamp = new Date().getTime();
 
-      const configFetcherClass = FakeConfigFetcherWithRules;
-      const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
-      const configCache = new FakeCache(cachedPc);
-      const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-      const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
-      const client = new ConfigCatClient(options, configCatKernel);
+    const configFetcherClass = FakeConfigFetcherWithRules;
+    const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
+    const configCache = new FakeCache(cachedPc);
+    const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
+    const client = new ConfigCatClient(options, configCatKernel);
 
-      const user = new User("a@configcat.com");
-      user.custom = { eyeColor: "red" };
+    const user = new User("a@configcat.com");
+    user.custom = { eyeColor: "red" };
 
-      const flagEvaluatedEvents: IEvaluationDetails[] = [];
-      client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
+    const flagEvaluatedEvents: IEvaluationDetails[] = [];
+    client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
 
-      // Act
+    // Act
 
-      const actual = await (isAsync
-        ? client.getValueDetailsAsync(key, defaultValue, user)
-        : new Promise<IEvaluationDetails>(resolve => client.getValueDetails(key, defaultValue, resolve, user))
-      );
+    const actual = await client.getValueDetailsAsync(key, defaultValue, user);
 
-      // Assert
+    // Assert
 
-      assert.strictEqual(key, actual.key);
-      assert.strictEqual("redValue", actual.value);
-      assert.isFalse(actual.isDefaultValue);
-      assert.strictEqual("redVariationId", actual.variationId);
-      assert.strictEqual(cachedPc.Timestamp, actual.fetchTime?.getTime());
-      assert.strictEqual(user, actual.user);
-      assert.isUndefined(actual.errorMessage);
-      assert.isUndefined(actual.errorException);
-      assert.isDefined(actual.matchedEvaluationRule);
-      assert.strictEqual(actual.value, actual.matchedEvaluationRule?.value);
-      assert.strictEqual(actual.variationId, actual.matchedEvaluationRule?.variationId);
-      assert.isUndefined(actual.matchedEvaluationPercentageRule);
+    assert.strictEqual(key, actual.key);
+    assert.strictEqual("redValue", actual.value);
+    assert.isFalse(actual.isDefaultValue);
+    assert.strictEqual("redVariationId", actual.variationId);
+    assert.strictEqual(cachedPc.Timestamp, actual.fetchTime?.getTime());
+    assert.strictEqual(user, actual.user);
+    assert.isUndefined(actual.errorMessage);
+    assert.isUndefined(actual.errorException);
+    assert.isDefined(actual.matchedEvaluationRule);
+    assert.strictEqual(actual.value, actual.matchedEvaluationRule?.value);
+    assert.strictEqual(actual.variationId, actual.matchedEvaluationRule?.variationId);
+    assert.isUndefined(actual.matchedEvaluationPercentageRule);
 
-      assert.equal(1, flagEvaluatedEvents.length);
-      assert.strictEqual(actual, flagEvaluatedEvents[0]);
-    });
+    assert.equal(1, flagEvaluatedEvents.length);
+    assert.strictEqual(actual, flagEvaluatedEvents[0]);
+  });
 
-    it(`getValueDetails${isAsync ? "Async" : ""}() should return correct result when setting is available and a percentage-based rule applies`, async () => {
+  it("getValueDetailsAsync() should return correct result when setting is available and a percentage-based rule applies", async () => {
 
-      // Arrange
+    // Arrange
 
-      const key = "string25Cat25Dog25Falcon25Horse";
-      const defaultValue = "N/A";
-      const timestamp = new Date().getTime();
+    const key = "string25Cat25Dog25Falcon25Horse";
+    const defaultValue = "N/A";
+    const timestamp = new Date().getTime();
 
-      const configFetcherClass = FakeConfigFetcherWithPercantageRules;
-      const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
-      const configCache = new FakeCache(cachedPc);
-      const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-      const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
-      const client = new ConfigCatClient(options, configCatKernel);
+    const configFetcherClass = FakeConfigFetcherWithPercantageRules;
+    const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
+    const configCache = new FakeCache(cachedPc);
+    const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
+    const client = new ConfigCatClient(options, configCatKernel);
 
-      const user = new User("a@configcat.com");
+    const user = new User("a@configcat.com");
 
-      const flagEvaluatedEvents: IEvaluationDetails[] = [];
-      client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
+    const flagEvaluatedEvents: IEvaluationDetails[] = [];
+    client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
 
-      // Act
+    // Act
 
-      const actual = await (isAsync
-        ? client.getValueDetailsAsync(key, defaultValue, user)
-        : new Promise<IEvaluationDetails>(resolve => client.getValueDetails(key, defaultValue, resolve, user))
-      );
+    const actual = await client.getValueDetailsAsync(key, defaultValue, user);
 
-      // Assert
+    // Assert
 
-      assert.strictEqual(key, actual.key);
-      assert.strictEqual("Cat", actual.value);
-      assert.isFalse(actual.isDefaultValue);
-      assert.strictEqual("CatVariationId", actual.variationId);
-      assert.strictEqual(cachedPc.Timestamp, actual.fetchTime?.getTime());
-      assert.strictEqual(user, actual.user);
-      assert.isUndefined(actual.errorMessage);
-      assert.isUndefined(actual.errorException);
-      assert.isUndefined(actual.matchedEvaluationRule);
-      assert.isDefined(actual.matchedEvaluationPercentageRule);
-      assert.strictEqual(actual.value, actual.matchedEvaluationPercentageRule?.value);
-      assert.strictEqual(actual.variationId, actual.matchedEvaluationPercentageRule?.variationId);
+    assert.strictEqual(key, actual.key);
+    assert.strictEqual("Cat", actual.value);
+    assert.isFalse(actual.isDefaultValue);
+    assert.strictEqual("CatVariationId", actual.variationId);
+    assert.strictEqual(cachedPc.Timestamp, actual.fetchTime?.getTime());
+    assert.strictEqual(user, actual.user);
+    assert.isUndefined(actual.errorMessage);
+    assert.isUndefined(actual.errorException);
+    assert.isUndefined(actual.matchedEvaluationRule);
+    assert.isDefined(actual.matchedEvaluationPercentageRule);
+    assert.strictEqual(actual.value, actual.matchedEvaluationPercentageRule?.value);
+    assert.strictEqual(actual.variationId, actual.matchedEvaluationPercentageRule?.variationId);
 
-      assert.equal(1, flagEvaluatedEvents.length);
-      assert.strictEqual(actual, flagEvaluatedEvents[0]);
-    });
+    assert.equal(1, flagEvaluatedEvents.length);
+    assert.strictEqual(actual, flagEvaluatedEvents[0]);
+  });
 
-    it(`getValueDetails${isAsync ? "Async" : ""}() should return default value when exception thrown`, async () => {
+  it("getValueDetailsAsync() should return default value when exception thrown", async () => {
 
-      // Arrange
+    // Arrange
 
-      const key = "debug";
-      const defaultValue = false;
-      const timestamp = new Date().getTime();
+    const key = "debug";
+    const defaultValue = false;
+    const timestamp = new Date().getTime();
 
-      const configFetcherClass = FakeConfigFetcherWithTwoKeys;
-      const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
-      const configCache = new FakeCache(cachedPc);
-      const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-      const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
-      const client = new ConfigCatClient(options, configCatKernel);
+    const configFetcherClass = FakeConfigFetcherWithTwoKeys;
+    const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
+    const configCache = new FakeCache(cachedPc);
+    const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
+    const client = new ConfigCatClient(options, configCatKernel);
 
-      const err = new Error("Something went wrong.");
-      client["evaluator"] = new class implements IRolloutEvaluator {
-        evaluate(setting: Setting, key: string, defaultValue: any, user: User | undefined, remoteConfig: ProjectConfig | null, defaultVariationId?: any): IEvaluationDetails {
-          throw err;
-        }
-      };
+    const err = new Error("Something went wrong.");
+    client["evaluator"] = new class implements IRolloutEvaluator {
+      evaluate(setting: Setting, key: string, defaultValue: any, user: User | undefined, remoteConfig: ProjectConfig | null, defaultVariationId?: any): IEvaluationDetails {
+        throw err;
+      }
+    };
 
-      const user = new User("a@configcat.com");
+    const user = new User("a@configcat.com");
 
-      const flagEvaluatedEvents: IEvaluationDetails[] = [];
-      const errorEvents: [string, any][] = [];
-      client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
-      client.on("clientError", (msg: string, err: any) => errorEvents.push([msg, err]));
+    const flagEvaluatedEvents: IEvaluationDetails[] = [];
+    const errorEvents: [string, any][] = [];
+    client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
+    client.on("clientError", (msg: string, err: any) => errorEvents.push([msg, err]));
 
-      // Act
+    // Act
 
-      const actual = await (isAsync
-        ? client.getValueDetailsAsync(key, defaultValue, user)
-        : new Promise<IEvaluationDetails>(resolve => client.getValueDetails(key, defaultValue, resolve, user))
-      );
+    const actual = await client.getValueDetailsAsync(key, defaultValue, user);
 
-      // Assert
+    // Assert
 
-      assert.strictEqual(key, actual.key);
-      assert.strictEqual(defaultValue, actual.value);
-      assert.isTrue(actual.isDefaultValue);
-      assert.isUndefined(actual.variationId);
-      assert.strictEqual(cachedPc.Timestamp, actual.fetchTime?.getTime());
-      assert.strictEqual(user, actual.user);
-      assert.isDefined(actual.errorMessage);
-      assert.strictEqual(err, actual.errorException);
-      assert.isUndefined(actual.matchedEvaluationRule);
-      assert.isUndefined(actual.matchedEvaluationPercentageRule);
+    assert.strictEqual(key, actual.key);
+    assert.strictEqual(defaultValue, actual.value);
+    assert.isTrue(actual.isDefaultValue);
+    assert.isUndefined(actual.variationId);
+    assert.strictEqual(cachedPc.Timestamp, actual.fetchTime?.getTime());
+    assert.strictEqual(user, actual.user);
+    assert.isDefined(actual.errorMessage);
+    assert.strictEqual(err, actual.errorException);
+    assert.isUndefined(actual.matchedEvaluationRule);
+    assert.isUndefined(actual.matchedEvaluationPercentageRule);
 
-      assert.equal(1, flagEvaluatedEvents.length);
-      assert.strictEqual(actual, flagEvaluatedEvents[0]);
+    assert.equal(1, flagEvaluatedEvents.length);
+    assert.strictEqual(actual, flagEvaluatedEvents[0]);
 
-      assert.equal(1, errorEvents.length);
-      const [actualErrorMessage, actualErrorException] = errorEvents[0];
-      expect(actualErrorMessage).to.include("Error occurred in the `getValueDetailsAsync` method");
+    assert.equal(1, errorEvents.length);
+    const [actualErrorMessage, actualErrorException] = errorEvents[0];
+    expect(actualErrorMessage).to.include("Error occurred in the `getValueDetailsAsync` method");
+    assert.strictEqual(err, actualErrorException);
+  });
+
+  it("getAllValueDetailsAsync() should return correct result", async () => {
+
+    // Arrange
+
+    const timestamp = new Date().getTime();
+
+    const configFetcherClass = FakeConfigFetcherWithTwoKeys;
+    const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
+    const configCache = new FakeCache(cachedPc);
+    const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
+    const client = new ConfigCatClient(options, configCatKernel);
+
+    const user = new User("a@configcat.com");
+
+    const flagEvaluatedEvents: IEvaluationDetails[] = [];
+    client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
+
+    // Act
+
+    const actual = await client.getAllValueDetailsAsync(user);
+
+    // Assert
+
+    const expected = [
+      { key: "debug", value: true, variationId: "abcdefgh" },
+      { key: "debug2", value: true, variationId: "12345678" },
+    ];
+
+    for (const { key, value, variationId } of expected) {
+      const actualDetails = actual.find(details => details.key === key)!;
+
+      assert.isDefined(actualDetails);
+      assert.strictEqual(value, actualDetails.value);
+      assert.isFalse(actualDetails.isDefaultValue);
+      assert.strictEqual(variationId, actualDetails.variationId);
+      assert.strictEqual(cachedPc.Timestamp, actualDetails.fetchTime?.getTime());
+      assert.strictEqual(user, actualDetails.user);
+      assert.isUndefined(actualDetails.errorMessage);
+      assert.isUndefined(actualDetails.errorException);
+      assert.isUndefined(actualDetails.matchedEvaluationRule);
+      assert.isUndefined(actualDetails.matchedEvaluationPercentageRule);
+
+      const flagEvaluatedDetails = flagEvaluatedEvents.find(details => details.key === key)!;
+
+      assert.isDefined(flagEvaluatedDetails);
+      assert.strictEqual(actualDetails, flagEvaluatedDetails);
+    }
+  });
+
+  it("getAllValueDetailsAsync() should return default value when exception thrown", async () => {
+
+    // Arrange
+
+    const timestamp = new Date().getTime();
+
+    const configFetcherClass = FakeConfigFetcherWithTwoKeys;
+    const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
+    const configCache = new FakeCache(cachedPc);
+    const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
+    const client = new ConfigCatClient(options, configCatKernel);
+
+    const err = new Error("Something went wrong.");
+    client["evaluator"] = new class implements IRolloutEvaluator {
+      evaluate(setting: Setting, key: string, defaultValue: any, user: User | undefined, remoteConfig: ProjectConfig | null, defaultVariationId?: any): IEvaluationDetails {
+        throw err;
+      }
+    };
+
+    const user = new User("a@configcat.com");
+
+    const flagEvaluatedEvents: IEvaluationDetails[] = [];
+    const errorEvents: [string, any][] = [];
+    client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
+    client.on("clientError", (msg: string, err: any) => errorEvents.push([msg, err]));
+
+    // Act
+
+    const actual = await client.getAllValueDetailsAsync(user);
+
+    // Assert
+
+    for (const key of ["debug", "debug2"]) {
+      const actualDetails = actual.find(details => details.key === key)!;
+
+      assert.isNull(actualDetails.value);
+      assert.isTrue(actualDetails.isDefaultValue);
+      assert.isUndefined(actualDetails.variationId);
+      assert.strictEqual(cachedPc.Timestamp, actualDetails.fetchTime?.getTime());
+      assert.strictEqual(user, actualDetails.user);
+      assert.isDefined(actualDetails.errorMessage);
+      assert.strictEqual(err, actualDetails.errorException);
+      assert.isUndefined(actualDetails.matchedEvaluationRule);
+      assert.isUndefined(actualDetails.matchedEvaluationPercentageRule);
+
+      const flagEvaluatedDetails = flagEvaluatedEvents.find(details => details.key === key)!;
+
+      assert.isDefined(flagEvaluatedDetails);
+      assert.strictEqual(actualDetails, flagEvaluatedDetails);
+    }
+
+    assert.equal(1, errorEvents.length);
+    const [actualErrorMessage, actualErrorException] = errorEvents[0];
+    expect(actualErrorMessage).to.include("Error occurred in the `getAllValueDetailsAsync` method.");
+    if (typeof AggregateError !== "undefined") {
+      assert.instanceOf(actualErrorException, AggregateError);
+      assert.deepEqual(Array(actual.length).fill(err), (actualErrorException as AggregateError).errors);
+    }
+    else {
       assert.strictEqual(err, actualErrorException);
-    });
-  }
-
-  for (const isAsync of [false, true]) {
-    it(`getAllValueDetails${isAsync ? "Async" : ""}() should return correct result`, async () => {
-
-      // Arrange
-
-      const timestamp = new Date().getTime();
-
-      const configFetcherClass = FakeConfigFetcherWithTwoKeys;
-      const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
-      const configCache = new FakeCache(cachedPc);
-      const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-      const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
-      const client = new ConfigCatClient(options, configCatKernel);
-
-      const user = new User("a@configcat.com");
-
-      const flagEvaluatedEvents: IEvaluationDetails[] = [];
-      client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
-
-      // Act
-
-      const actual = await (isAsync
-        ? client.getAllValueDetailsAsync(user)
-        : new Promise<IEvaluationDetails[]>(resolve => client.getAllValueDetails(resolve, user))
-      );
-
-      // Assert
-
-      const expected = [
-        { key: "debug", value: true, variationId: "abcdefgh" },
-        { key: "debug2", value: true, variationId: "12345678" },
-      ];
-
-      for (const { key, value, variationId } of expected) {
-        const actualDetails = actual.find(details => details.key === key)!;
-
-        assert.isDefined(actualDetails);
-        assert.strictEqual(value, actualDetails.value);
-        assert.isFalse(actualDetails.isDefaultValue);
-        assert.strictEqual(variationId, actualDetails.variationId);
-        assert.strictEqual(cachedPc.Timestamp, actualDetails.fetchTime?.getTime());
-        assert.strictEqual(user, actualDetails.user);
-        assert.isUndefined(actualDetails.errorMessage);
-        assert.isUndefined(actualDetails.errorException);
-        assert.isUndefined(actualDetails.matchedEvaluationRule);
-        assert.isUndefined(actualDetails.matchedEvaluationPercentageRule);
-
-        const flagEvaluatedDetails = flagEvaluatedEvents.find(details => details.key === key)!;
-
-        assert.isDefined(flagEvaluatedDetails);
-        assert.strictEqual(actualDetails, flagEvaluatedDetails);
-      }
-    });
-
-    it(`getAllValueDetails${isAsync ? "Async" : ""}() should return default value when exception thrown`, async () => {
-
-      // Arrange
-
-      const timestamp = new Date().getTime();
-
-      const configFetcherClass = FakeConfigFetcherWithTwoKeys;
-      const cachedPc = new ProjectConfig(timestamp, configFetcherClass.configJson, "etag");
-      const configCache = new FakeCache(cachedPc);
-      const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-      const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCache);
-      const client = new ConfigCatClient(options, configCatKernel);
-
-      const err = new Error("Something went wrong.");
-      client["evaluator"] = new class implements IRolloutEvaluator {
-        evaluate(setting: Setting, key: string, defaultValue: any, user: User | undefined, remoteConfig: ProjectConfig | null, defaultVariationId?: any): IEvaluationDetails {
-          throw err;
-        }
-      };
-
-      const user = new User("a@configcat.com");
-
-      const flagEvaluatedEvents: IEvaluationDetails[] = [];
-      const errorEvents: [string, any][] = [];
-      client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
-      client.on("clientError", (msg: string, err: any) => errorEvents.push([msg, err]));
-
-      // Act
-
-      const actual = await (isAsync
-        ? client.getAllValueDetailsAsync(user)
-        : new Promise<IEvaluationDetails[]>(resolve => client.getAllValueDetails(resolve, user))
-      );
-
-      // Assert
-
-      for (const key of ["debug", "debug2"]) {
-        const actualDetails = actual.find(details => details.key === key)!;
-
-        assert.isNull(actualDetails.value);
-        assert.isTrue(actualDetails.isDefaultValue);
-        assert.isUndefined(actualDetails.variationId);
-        assert.strictEqual(cachedPc.Timestamp, actualDetails.fetchTime?.getTime());
-        assert.strictEqual(user, actualDetails.user);
-        assert.isDefined(actualDetails.errorMessage);
-        assert.strictEqual(err, actualDetails.errorException);
-        assert.isUndefined(actualDetails.matchedEvaluationRule);
-        assert.isUndefined(actualDetails.matchedEvaluationPercentageRule);
-
-        const flagEvaluatedDetails = flagEvaluatedEvents.find(details => details.key === key)!;
-
-        assert.isDefined(flagEvaluatedDetails);
-        assert.strictEqual(actualDetails, flagEvaluatedDetails);
-      }
-
-      assert.equal(1, errorEvents.length);
-      const [actualErrorMessage, actualErrorException] = errorEvents[0];
-      expect(actualErrorMessage).to.include("Error occurred in the `getAllValueDetailsAsync` method.");
-      if (typeof AggregateError !== "undefined") {
-        assert.instanceOf(actualErrorException, AggregateError);
-        assert.deepEqual(Array(actual.length).fill(err), (actualErrorException as AggregateError).errors);
-      }
-      else {
-        assert.strictEqual(err, actualErrorException);
-      }
-    });
-  }
+    }
+  });
 
   it("Initialization With AutoPollOptions - config changed in every fetch - should fire configChanged every polling iteration", async () => {
 
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcherWithAlwaysVariableEtag(), sdkType: "common", sdkVersion: "1.0.0" };
-    let counter = 0;
     let configChangedEventCount = 0;
     const pollIntervalSeconds = 1;
     const userOptions: IAutoPollOptions = {
       logger: null,
       pollIntervalSeconds,
-      configChanged: () => { counter++; },
       setupHooks: hooks => hooks.on("configChanged", () => configChangedEventCount++)
     };
     const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", userOptions, null);
@@ -651,7 +493,6 @@ describe("ConfigCatClient", () => {
 
     await delay(2.5 * pollIntervalSeconds * 1000);
 
-    assert.equal(counter, 3);
     assert.equal(configChangedEventCount, 3);
   });
 
@@ -769,18 +610,6 @@ describe("ConfigCatClient", () => {
     assert.deepEqual(flagEvaluatedEvents.map(evt => [evt.key, evt.value]), actual.map(kv => [kv.settingKey, kv.settingValue]));
   });
 
-  it("getAllValues - works", (done) => {
-
-    const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcherWithTwoKeys(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", {}, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-
-    client.getAllValues(actual => {
-      assert.equal(actual.length, 2);
-      done();
-    });
-  });
-
   it("getAllValuesAsync - without config - return empty array", async () => {
 
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcherWithNullNewConfig(), sdkType: "common", sdkVersion: "1.0.0" };
@@ -828,8 +657,8 @@ describe("ConfigCatClient", () => {
       }
     };
 
-    client.getValue("debug", false, callback);
-    client.getValue("debug", false, callback);
+    client.getValueAsync("debug", false).then(callback);
+    client.getValueAsync("debug", false).then(callback);
   });
 
   it("Initialization With AutoPollOptions with expired cache - getValue should take care of maxInitWaitTimeSeconds", done => {
@@ -840,7 +669,7 @@ describe("ConfigCatClient", () => {
     const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { cache: configCache, maxInitWaitTimeSeconds: 10 });
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
-    client.getValue("debug", false, value => {
+    client.getValueAsync("debug", false).then(value => {
       done(value === true ? null : new Error("Wrong value."));
     });
   });

--- a/test/ConfigCatLoggerTests.ts
+++ b/test/ConfigCatLoggerTests.ts
@@ -45,48 +45,5 @@ describe("ConfigCatLogger", () => {
 
       assert.equal(messages.length, expectedCount);
     });
-
-    it(`Deprecated logging works with level ${LogLevel[level]}`, () => {
-      const messages: [LogLevel, string][] = [];
-
-      const loggerImpl = new class implements IConfigCatLogger {
-        level = level;
-        debug?(message: string): void { messages.push([LogLevel.Debug, message]); }
-        info?(message: string): void { messages.push([LogLevel.Info, message]); }
-        warn?(message: string): void { messages.push([LogLevel.Warn, message]); }
-        error?(message: string): void { messages.push([LogLevel.Error, message]); }
-      };
-
-      const logger = new LoggerWrapper(loggerImpl);
-      const err = new Error();
-
-      logger.logEvent(LogLevel.Debug, 0, `${LogLevel[LogLevel.Debug]} message`);
-      logger.logEvent(LogLevel.Info, 1, `${LogLevel[LogLevel.Info]} message`);
-      logger.logEvent(LogLevel.Warn, 2, `${LogLevel[LogLevel.Warn]} message`);
-      logger.logEvent(LogLevel.Error, 3, `${LogLevel[LogLevel.Error]} message`, err);
-
-      let expectedCount = 0;
-      if (level >= LogLevel.Debug) {
-        assert.equal(messages.filter(([level, msg]) => level === LogLevel.Debug && msg === `${LogLevel[level]} message`).length, 1);
-        expectedCount++;
-      }
-
-      if (level >= LogLevel.Info) {
-        assert.equal(messages.filter(([level, msg]) => level === LogLevel.Info && msg === `${LogLevel[level]} message`).length, 1);
-        expectedCount++;
-      }
-
-      if (level >= LogLevel.Warn) {
-        assert.equal(messages.filter(([level, msg]) => level === LogLevel.Warn && msg === `${LogLevel[level]} message`).length, 1);
-        expectedCount++;
-      }
-
-      if (level >= LogLevel.Error) {
-        assert.equal(messages.filter(([level, msg]) => level === LogLevel.Error && msg === `${LogLevel[level]} message`).length, 1);
-        expectedCount++;
-      }
-
-      assert.equal(messages.length, expectedCount);
-    });
   }
 });

--- a/test/ConfigCatLoggerTests.ts
+++ b/test/ConfigCatLoggerTests.ts
@@ -9,7 +9,7 @@ describe("ConfigCatLogger", () => {
 
       const loggerImpl = new class implements IConfigCatLogger {
         level = level;
-        logEvent(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any) {
+        log(level: LogLevel, eventId: LogEventId, message: LogMessage, exception?: any) {
           messages.push([level, eventId, message, exception]);
         }
       };
@@ -17,10 +17,10 @@ describe("ConfigCatLogger", () => {
       const logger = new LoggerWrapper(loggerImpl);
       const err = new Error();
 
-      logger.logEvent(LogLevel.Debug, 0, `${LogLevel[LogLevel.Debug]} message`);
-      logger.logEvent(LogLevel.Info, 1, `${LogLevel[LogLevel.Info]} message`);
-      logger.logEvent(LogLevel.Warn, 2, `${LogLevel[LogLevel.Warn]} message`);
-      logger.logEvent(LogLevel.Error, 3, `${LogLevel[LogLevel.Error]} message`, err);
+      logger.log(LogLevel.Debug, 0, `${LogLevel[LogLevel.Debug]} message`);
+      logger.log(LogLevel.Info, 1, `${LogLevel[LogLevel.Info]} message`);
+      logger.log(LogLevel.Warn, 2, `${LogLevel[LogLevel.Warn]} message`);
+      logger.log(LogLevel.Error, 3, `${LogLevel[LogLevel.Error]} message`, err);
 
       let expectedCount = 0;
       if (level >= LogLevel.Debug) {

--- a/test/IndexTests.ts
+++ b/test/IndexTests.ts
@@ -1,32 +1,48 @@
 import { assert } from "chai";
 import "mocha";
+import { PollingMode } from "../lib";
 import { IConfigCatClient } from "../src/ConfigCatClient";
 import * as configcatClient from "../src/index";
 import { FakeConfigCatKernel, FakeConfigFetcher } from "./helpers/fakes";
 
 describe("ConfigCatClient index (main)", () => {
 
-  it("createClientWithAutoPoll ShouldCreateInstance", () => {
+  it("getClient ShouldCreateInstance - AutoPoll", () => {
 
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcher(), sdkType: "common", sdkVersion: "1.0.0" };
-    const client: IConfigCatClient = configcatClient.createClientWithAutoPoll("APIKEY", configCatKernel);
+    const client: IConfigCatClient = configcatClient.getClient("APIKEY", PollingMode.AutoPoll, void 0, configCatKernel);
 
-    assert.isDefined(client);
+    try {
+      assert.isDefined(client);
+    }
+    finally {
+      client.dispose();
+    }
   });
 
-  it("createClientWithLazyLoad ShouldCreateInstance", () => {
+  it("getClient ShouldCreateInstance - LazyLoad", () => {
 
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcher(), sdkType: "common", sdkVersion: "1.0.0" };
-    const client: IConfigCatClient = configcatClient.createClientWithLazyLoad("APIKEY", configCatKernel);
+    const client: IConfigCatClient = configcatClient.getClient("APIKEY", PollingMode.LazyLoad, void 0, configCatKernel);
 
-    assert.isDefined(client);
+    try {
+      assert.isDefined(client);
+    }
+    finally {
+      client.dispose();
+    }
   });
 
-  it("createClientWithManualPoll ShouldCreateInstance", () => {
+  it("getClient ShouldCreateInstance - ManualPoll", () => {
 
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcher(), sdkType: "common", sdkVersion: "1.0.0" };
-    const client: IConfigCatClient = configcatClient.createClientWithManualPoll("APIKEY", configCatKernel);
+    const client: IConfigCatClient = configcatClient.getClient("APIKEY", PollingMode.ManualPoll, void 0, configCatKernel);
 
-    assert.isDefined(client);
+    try {
+      assert.isDefined(client);
+    }
+    finally {
+      client.dispose();
+    }
   });
 });

--- a/test/MatrixTests.ts
+++ b/test/MatrixTests.ts
@@ -2,10 +2,10 @@ import { assert } from "chai";
 import * as fs from "fs";
 import "mocha";
 import { EOL } from "os";
-import { createClientWithManualPoll } from "../src";
 import { ConfigCatConsoleLogger, LogLevel } from "../src/ConfigCatLogger";
 import { User } from "../src/RolloutEvaluator";
 import { FakeConfigCatKernel, FakeConfigFetcherBase } from "./helpers/fakes";
+import { createClientWithManualPoll } from "./helpers/utils";
 
 describe("MatrixTests", () => {
 

--- a/test/VariationIdMatrixTests.ts
+++ b/test/VariationIdMatrixTests.ts
@@ -42,7 +42,7 @@ describe("MatrixTests", () => {
 
           const key: string = header[i];
           const expected = splittedLine[i];
-          const actual = await client.getVariationIdAsync(key, null, user);
+          const actual = (await client.getValueDetailsAsync(key, null, user)).variationId;
 
           if (actual !== expected) {
 

--- a/test/VariationIdTests.ts
+++ b/test/VariationIdTests.ts
@@ -6,117 +6,6 @@ import { IEvaluationDetails } from "../src/RolloutEvaluator";
 import { FakeConfigCatKernel, FakeConfigFetcherWithNullNewConfig, FakeConfigFetcherWithTwoKeys, FakeConfigFetcherWithTwoKeysAndRules } from "./helpers/fakes";
 
 describe("ConfigCatClient", () => {
-  it("getVariationId() works", (done) => {
-
-    const configCatKernel: FakeConfigCatKernel = {
-      configFetcher: new FakeConfigFetcherWithTwoKeys(),
-      sdkType: "common",
-      sdkVersion: "1.0.0"
-    };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-    assert.isDefined(client);
-
-    client.getVariationId("debug", "N/A", (variationId) => {
-      assert.equal(variationId, "abcdefgh");
-
-      client.getVariationId("debug2", "N/A", (variationId) => {
-        assert.equal(variationId, "12345678");
-
-        client.getVariationId("notexists", "N/A", (variationId) => {
-          assert.equal(variationId, "N/A");
-
-          client.getVariationId("notexists2", "N/A", (variationId) => {
-            assert.equal(variationId, "N/A");
-
-            done();
-          });
-        });
-      });
-    });
-  });
-
-  it("getVariationIdAsync() works", async () => {
-    const configCatKernel: FakeConfigCatKernel = {
-      configFetcher: new FakeConfigFetcherWithTwoKeys(),
-      sdkType: "common",
-      sdkVersion: "1.0.0"
-    };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-    assert.isDefined(client);
-
-    const flagEvaluatedEvents: IEvaluationDetails[] = [];
-    client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
-
-    assert.equal(await client.getVariationIdAsync("debug", "N/A"), "abcdefgh");
-    assert.equal(await client.getVariationIdAsync("debug2", "N/A"), "12345678");
-    assert.equal(await client.getVariationIdAsync("notexists", "N/A"), "N/A");
-    assert.equal(await client.getVariationIdAsync("notexists2", "N/A"), "N/A");
-
-    assert.equal(4, flagEvaluatedEvents.length);
-    assert.strictEqual("abcdefgh", flagEvaluatedEvents[0].variationId);
-    assert.strictEqual("12345678", flagEvaluatedEvents[1].variationId);
-    assert.strictEqual("N/A", flagEvaluatedEvents[2].variationId);
-    assert.strictEqual("N/A", flagEvaluatedEvents[3].variationId);
-  });
-
-  it("getAllVariationIds() works", (done) => {
-
-    const configCatKernel: FakeConfigCatKernel = {
-      configFetcher: new FakeConfigFetcherWithTwoKeys(),
-      sdkType: "common",
-      sdkVersion: "1.0.0"
-    };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-    assert.isDefined(client);
-
-    client.getAllVariationIds((variationIds) => {
-      assert.equal(variationIds.length, 2);
-      assert.equal(variationIds[0], "abcdefgh");
-      assert.equal(variationIds[1], "12345678");
-      done();
-    });
-  });
-
-  it("getAllVariationIdsAsync() works", async () => {
-    const configCatKernel: FakeConfigCatKernel = {
-      configFetcher: new FakeConfigFetcherWithTwoKeys(),
-      sdkType: "common",
-      sdkVersion: "1.0.0"
-    };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-    assert.isDefined(client);
-
-    const flagEvaluatedEvents: IEvaluationDetails[] = [];
-    client.on("flagEvaluated", ed => flagEvaluatedEvents.push(ed));
-
-    const variationIds = await client.getAllVariationIdsAsync();
-    assert.equal(variationIds.length, 2);
-    assert.equal(variationIds[0], "abcdefgh");
-    assert.equal(variationIds[1], "12345678");
-
-    assert.deepEqual(flagEvaluatedEvents.map(evt => evt.variationId), variationIds);
-  });
-
-  it("getKeyAndValue() works with default", (done) => {
-    const configCatKernel: FakeConfigCatKernel = {
-      configFetcher: new FakeConfigFetcherWithTwoKeysAndRules(),
-      sdkType: "common",
-      sdkVersion: "1.0.0"
-    };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-
-    client.getKeyAndValue("abcdefgh", (result) => {
-      assert.equal(result?.settingKey, "debug");
-      assert.equal(result?.settingValue, "def");
-      done();
-    });
-  });
-
   it("getKeyAndValueAsync() works with default", async () => {
     const configCatKernel: FakeConfigCatKernel = {
       configFetcher: new FakeConfigFetcherWithTwoKeysAndRules(),
@@ -131,22 +20,6 @@ describe("ConfigCatClient", () => {
     assert.equal(result?.settingValue, "def");
   });
 
-  it("getKeyAndValue() works with rollout rules", (done) => {
-    const configCatKernel: FakeConfigCatKernel = {
-      configFetcher: new FakeConfigFetcherWithTwoKeysAndRules(),
-      sdkType: "common",
-      sdkVersion: "1.0.0"
-    };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-
-    client.getKeyAndValue("6ada5ff2", (result) => {
-      assert.equal(result?.settingKey, "debug");
-      assert.equal(result?.settingValue, "value");
-      done();
-    });
-  });
-
   it("getKeyAndValueAsync() works with rollout rules", async () => {
     const configCatKernel: FakeConfigCatKernel = {
       configFetcher: new FakeConfigFetcherWithTwoKeysAndRules(),
@@ -159,22 +32,6 @@ describe("ConfigCatClient", () => {
     const result = await client.getKeyAndValueAsync("6ada5ff2");
     assert.equal(result?.settingKey, "debug");
     assert.equal(result?.settingValue, "value");
-  });
-
-  it("getKeyAndValue() works with percentage rules", (done) => {
-    const configCatKernel: FakeConfigCatKernel = {
-      configFetcher: new FakeConfigFetcherWithTwoKeysAndRules(),
-      sdkType: "common",
-      sdkVersion: "1.0.0"
-    };
-    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", { logger: null }, null);
-    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
-
-    client.getKeyAndValue("622f5d07", (result) => {
-      assert.equal(result?.settingKey, "debug2");
-      assert.equal(result?.settingValue, "value2");
-      done();
-    });
   });
 
   it("getKeyAndValueAsync() works with percentage rules", async () => {

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -1,7 +1,7 @@
 import { ICache } from "../../src/Cache";
 import { IConfigCatKernel } from "../../src/ConfigCatClient";
 import { OptionsBase } from "../../src/ConfigCatClientOptions";
-import { IConfigCatLogger, LogLevel } from "../../src/ConfigCatLogger";
+import { IConfigCatLogger, LogLevel, LogMessage } from "../../src/ConfigCatLogger";
 import { IConfigFetcher, IFetchResponse } from "../../src/ConfigFetcher";
 import { ProjectConfig } from "../../src/ProjectConfig";
 import { delay } from "../../src/Utils";
@@ -13,24 +13,8 @@ export class FakeLogger implements IConfigCatLogger {
 
   reset(): void { this.messages.splice(0); }
 
-  log(message: string): void {
-    this.info(message);
-  }
-
-  debug(message: string): void {
-    this.messages.push([LogLevel.Debug, message]);
-  }
-
-  info(message: string): void {
-    this.messages.push([LogLevel.Info, message]);
-  }
-
-  warn(message: string): void {
-    this.messages.push([LogLevel.Warn, message]);
-  }
-
-  error(message: string): void {
-    this.messages.push([LogLevel.Error, message]);
+  logEvent(level: LogLevel, _eventId: number, message: LogMessage, _exception?: any): void {
+    this.messages.push([level, message.toString()]);
   }
 }
 

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -13,7 +13,7 @@ export class FakeLogger implements IConfigCatLogger {
 
   reset(): void { this.messages.splice(0); }
 
-  logEvent(level: LogLevel, _eventId: number, message: LogMessage, _exception?: any): void {
+  log(level: LogLevel, _eventId: number, message: LogMessage, _exception?: any): void {
     this.messages.push([level, message.toString()]);
   }
 }

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -1,4 +1,20 @@
+import { IAutoPollOptions, IConfigCatKernel, ILazyLoadingOptions, IManualPollOptions } from "../../src";
+import { ConfigCatClient, IConfigCatClient } from "../../src/ConfigCatClient";
+import { AutoPollOptions, LazyLoadOptions, ManualPollOptions } from "../../src/ConfigCatClientOptions";
+
 // See https://stackoverflow.com/a/72237137/8656352
 export function allowEventLoop(waitMs = 0): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, waitMs));
+}
+
+export function createClientWithAutoPoll(apiKey: string, configCatKernel: IConfigCatKernel, options?: IAutoPollOptions): IConfigCatClient {
+  return new ConfigCatClient(new AutoPollOptions(apiKey, configCatKernel.sdkType, configCatKernel.sdkVersion, options, configCatKernel.cache, configCatKernel.eventEmitterFactory), configCatKernel);
+}
+
+export function createClientWithManualPoll(apiKey: string, configCatKernel: IConfigCatKernel, options?: IManualPollOptions): IConfigCatClient {
+  return new ConfigCatClient(new ManualPollOptions(apiKey, configCatKernel.sdkType, configCatKernel.sdkVersion, options, configCatKernel.cache, configCatKernel.eventEmitterFactory), configCatKernel);
+}
+
+export function createClientWithLazyLoad(apiKey: string, configCatKernel: IConfigCatKernel, options?: ILazyLoadingOptions): IConfigCatClient {
+  return new ConfigCatClient(new LazyLoadOptions(apiKey, configCatKernel.sdkType, configCatKernel.sdkVersion, options, configCatKernel.cache, configCatKernel.eventEmitterFactory), configCatKernel);
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

Removes deprecated code.

Breaking changes:
* Removes the `createClientWithAutoPoll`, `createClientWithManualPoll`, `createClientWithLazyLoad` factory functions. Alternative: `getClient`.
* Removes all the non-async `getXxx` methods from `IConfigCatClient`/`ConfigCatClient` as these are not synchronous implementations, just call into the async versions. Alternative: `getXxxAsync(...).then(callback)`
* Removes the non-async `forceRefresh` method from `IConfigCatClient`/`ConfigCatClient` as this is not a synchronous implementation, just calls into the async version. Alternative: `forceRefreshAsync().then(callback)`
* Removes the `IAutoPollOptions.configChanged` callback. Alternative: `options.setupHooks = hooks => hooks.on("configChanged", ...)`.
* Removes the `debug`, `info`, `warn` and `error` methods from `IConfigCatLogger` and changes the signature of the `log` method, which is now the single method that needs to be implemented for custom logging.
* Removes the `getVariationId`/`getVariationIdAsync` and `getAllVariationIds`/`getAllVariationIdsAsync` methods from `IConfigCatClient`/`ConfigCatClient`. Alternative: `getValueDetailsAsync` and `getAllValueDetailsAsync`.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
