### PR TITLE
Fix validation of polling mode intervals

### DIFF
--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -10,20 +10,20 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
 
   private initialized: boolean;
   private readonly initialization: Promise<void>;
-  private signalInitialization: () => void = (void 0)!; // the initial value is only for keeping the TS compiler happy
+  private signalInitialization: () => void = () => { /* Intentional no-op. */ };
   private timerId?: ReturnType<typeof setTimeout>;
 
   constructor(configFetcher: IConfigFetcher, options: AutoPollOptions) {
 
     super(configFetcher, options);
 
-    if (options.maxInitWaitTimeSeconds > 0) {
+    if (options.maxInitWaitTimeSeconds !== 0) {
       this.initialized = false;
 
       // This promise will be resolved when
       // 1. the cache contains a valid config at startup (see startRefreshWorker) or
       // 2. config.json is downloaded the first time (see onConfigUpdated) or
-      // 3. maxInitWaitTimeSeconds has passed (see the setTimeout call below).
+      // 3. maxInitWaitTimeSeconds > 0 and maxInitWaitTimeSeconds has passed (see the setTimeout call below).
       this.initialization = new Promise(resolve => this.signalInitialization = () => {
         this.initialized = true;
         resolve();
@@ -31,7 +31,9 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
 
       this.initialization.then(() => !this.disposed && options.hooks.emit("clientReady"));
 
-      setTimeout(() => this.signalInitialization(), options.maxInitWaitTimeSeconds * 1000);
+      if (options.maxInitWaitTimeSeconds > 0) {
+        setTimeout(() => this.signalInitialization(), options.maxInitWaitTimeSeconds * 1000);
+      }
     }
     else {
       this.initialized = true;
@@ -40,11 +42,16 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
     }
 
     if (!options.offline) {
-      this.startRefreshWorker(options.pollIntervalSeconds * 1000);
+      this.startRefreshWorker();
     }
   }
 
   private async waitForInitializationAsync(): Promise<boolean> {
+    if (this.options.maxInitWaitTimeSeconds < 0) {
+      await this.initialization;
+      return true;
+    }
+
     let cancelDelay: () => void;
     // Simply awaiting the initialization promise would also work but we limit waiting to maxInitWaitTimeSeconds for maximum safety.
     const result = await Promise.race([
@@ -109,15 +116,17 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
   }
 
   protected setOnlineCore(): void {
-    this.startRefreshWorker(this.options.pollIntervalSeconds * 1000);
+    this.startRefreshWorker();
   }
 
   protected setOfflineCore(): void {
     this.stopRefreshWorker();
   }
 
-  private async startRefreshWorker(delayMs: number) {
+  private async startRefreshWorker() {
     this.options.logger.logDebug("AutoPollConfigService.startRefreshWorker() called.");
+
+    const delayMs = this.options.pollIntervalSeconds * 1000;
 
     const latestConfig = await this.options.cache.get(this.options.getCacheKey());
     if (ProjectConfig.isExpired(latestConfig, this.options.pollIntervalSeconds * 1000)) {

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -52,8 +52,16 @@ export interface IOptions {
 }
 
 export interface IAutoPollOptions extends IOptions {
+  /**
+   * Configuration refresh period.
+   * (Default value is 60 seconds. Minimum value is 1 second. Maximum value is 2147483.647 seconds.)
+   */
   pollIntervalSeconds?: number;
 
+  /**
+    * Maximum waiting time between initialization and the first config acquisition.
+    * (Default value is 5 seconds. Maximum value is 2147483.647 seconds. Negative values mean infinite waiting.)
+   */
   maxInitWaitTimeSeconds?: number;
 
   configChanged?: () => void;
@@ -63,6 +71,10 @@ export interface IManualPollOptions extends IOptions {
 }
 
 export interface ILazyLoadingOptions extends IOptions {
+  /**
+    * Cache time to live value.
+    * (Default value is 60 seconds. Minimum value is 1 second.)
+   */
   cacheTimeToLiveSeconds?: number;
 }
 
@@ -71,6 +83,10 @@ export type OptionsForPollingMode<TMode extends PollingMode> =
   TMode extends PollingMode.ManualPoll ? IManualPollOptions :
   TMode extends PollingMode.LazyLoad ? ILazyLoadingOptions :
   never;
+
+// https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+// https://stackoverflow.com/a/3468650/8656352
+const maxSetTimeoutIntervalSecs = 2147483.647;
 
 /* eslint-disable @typescript-eslint/no-inferrable-types */
 
@@ -185,7 +201,6 @@ export abstract class OptionsBase implements IOptions {
 
 export class AutoPollOptions extends OptionsBase implements IAutoPollOptions {
 
-  /** The client's poll interval in seconds. Default: 60 seconds. */
   pollIntervalSeconds: number = 60;
 
   /** You can subscribe to configuration changes with this callback.
@@ -193,7 +208,6 @@ export class AutoPollOptions extends OptionsBase implements IAutoPollOptions {
    */
   configChanged: () => void = () => { };
 
-  /** Maximum waiting time between the client initialization and the first config acquisition in seconds. */
   maxInitWaitTimeSeconds: number = 5;
 
   constructor(apiKey: string, sdkType: string, sdkVersion: string, options?: IAutoPollOptions | null, defaultCache?: ICache | null, eventEmitterFactory?: (() => IEventEmitter) | null) {
@@ -215,11 +229,11 @@ export class AutoPollOptions extends OptionsBase implements IAutoPollOptions {
       }
     }
 
-    if (!(this.pollIntervalSeconds >= 1 && (typeof this.pollIntervalSeconds === "number"))) {
+    if (!(typeof this.pollIntervalSeconds === "number" && 1 <= this.pollIntervalSeconds && this.pollIntervalSeconds <= maxSetTimeoutIntervalSecs)) {
       throw new Error("Invalid 'pollIntervalSeconds' value");
     }
 
-    if (!(this.maxInitWaitTimeSeconds >= 0 && (typeof this.maxInitWaitTimeSeconds === "number"))) {
+    if (!(typeof this.maxInitWaitTimeSeconds === "number" && this.pollIntervalSeconds <= maxSetTimeoutIntervalSecs)) {
       throw new Error("Invalid 'maxInitWaitTimeSeconds' value");
     }
   }
@@ -233,7 +247,6 @@ export class ManualPollOptions extends OptionsBase implements IManualPollOptions
 
 export class LazyLoadOptions extends OptionsBase implements ILazyLoadingOptions {
 
-  /** The cache TTL. */
   cacheTimeToLiveSeconds: number = 60;
 
   constructor(apiKey: string, sdkType: string, sdkVersion: string, options?: ILazyLoadingOptions | null, defaultCache?: ICache | null, eventEmitterFactory?: (() => IEventEmitter) | null) {
@@ -241,13 +254,13 @@ export class LazyLoadOptions extends OptionsBase implements ILazyLoadingOptions 
     super(apiKey, sdkType + "/l-" + sdkVersion, options, defaultCache, eventEmitterFactory);
 
     if (options) {
-      if (options.cacheTimeToLiveSeconds) {
+      if (options.cacheTimeToLiveSeconds !== void 0 && options.cacheTimeToLiveSeconds !== null) {
         this.cacheTimeToLiveSeconds = options.cacheTimeToLiveSeconds;
       }
     }
 
-    if (!this.cacheTimeToLiveSeconds || this.cacheTimeToLiveSeconds < 1) {
-      throw new Error("Invalid 'cacheTimeToLiveSeconds' value. Value must be greater than zero.");
+    if (!(typeof this.cacheTimeToLiveSeconds === "number" && 1 <= this.cacheTimeToLiveSeconds)) {
+      throw new Error("Invalid 'cacheTimeToLiveSeconds' value");
     }
   }
 }

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -54,13 +54,13 @@ export interface IOptions {
 export interface IAutoPollOptions extends IOptions {
   /**
    * Configuration refresh period.
-   * (Default value is 60 seconds. Minimum value is 1 second. Maximum value is 2147483.647 seconds.)
+   * (Default value is 60 seconds. Minimum value is 1 second. Maximum value is 2147483 seconds.)
    */
   pollIntervalSeconds?: number;
 
   /**
     * Maximum waiting time between initialization and the first config acquisition.
-    * (Default value is 5 seconds. Maximum value is 2147483.647 seconds. Negative values mean infinite waiting.)
+    * (Default value is 5 seconds. Maximum value is 2147483 seconds. Negative values mean infinite waiting.)
    */
   maxInitWaitTimeSeconds?: number;
 
@@ -227,7 +227,7 @@ export class AutoPollOptions extends OptionsBase implements IAutoPollOptions {
 
     // https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
     // https://stackoverflow.com/a/3468650/8656352
-    const maxSetTimeoutIntervalSecs = 2147483.647;
+    const maxSetTimeoutIntervalSecs = 2147483;
 
     if (!(typeof this.pollIntervalSeconds === "number" && 1 <= this.pollIntervalSeconds && this.pollIntervalSeconds <= maxSetTimeoutIntervalSecs)) {
       throw new Error("Invalid 'pollIntervalSeconds' value");

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -73,7 +73,7 @@ export interface IManualPollOptions extends IOptions {
 export interface ILazyLoadingOptions extends IOptions {
   /**
     * Cache time to live value.
-    * (Default value is 60 seconds. Minimum value is 1 second.)
+    * (Default value is 60 seconds. Minimum value is 1 second. Maximum value is 2147483647 seconds.)
    */
   cacheTimeToLiveSeconds?: number;
 }
@@ -83,10 +83,6 @@ export type OptionsForPollingMode<TMode extends PollingMode> =
   TMode extends PollingMode.ManualPoll ? IManualPollOptions :
   TMode extends PollingMode.LazyLoad ? ILazyLoadingOptions :
   never;
-
-// https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
-// https://stackoverflow.com/a/3468650/8656352
-const maxSetTimeoutIntervalSecs = 2147483.647;
 
 /* eslint-disable @typescript-eslint/no-inferrable-types */
 
@@ -229,11 +225,15 @@ export class AutoPollOptions extends OptionsBase implements IAutoPollOptions {
       }
     }
 
+    // https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+    // https://stackoverflow.com/a/3468650/8656352
+    const maxSetTimeoutIntervalSecs = 2147483.647;
+
     if (!(typeof this.pollIntervalSeconds === "number" && 1 <= this.pollIntervalSeconds && this.pollIntervalSeconds <= maxSetTimeoutIntervalSecs)) {
       throw new Error("Invalid 'pollIntervalSeconds' value");
     }
 
-    if (!(typeof this.maxInitWaitTimeSeconds === "number" && this.pollIntervalSeconds <= maxSetTimeoutIntervalSecs)) {
+    if (!(typeof this.maxInitWaitTimeSeconds === "number" && this.maxInitWaitTimeSeconds <= maxSetTimeoutIntervalSecs)) {
       throw new Error("Invalid 'maxInitWaitTimeSeconds' value");
     }
   }
@@ -259,7 +259,7 @@ export class LazyLoadOptions extends OptionsBase implements ILazyLoadingOptions 
       }
     }
 
-    if (!(typeof this.cacheTimeToLiveSeconds === "number" && 1 <= this.cacheTimeToLiveSeconds)) {
+    if (!(typeof this.cacheTimeToLiveSeconds === "number" && 1 <= this.cacheTimeToLiveSeconds && this.cacheTimeToLiveSeconds <= 2147483647)) {
       throw new Error("Invalid 'cacheTimeToLiveSeconds' value");
     }
   }

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -162,12 +162,6 @@ describe("Options", () => {
     assert.notEqual("https://cdn-global.configcat.com/configuration-files/APIKEY/config_v5.json?sdk=common/a-1.0.0", options.getUrl());
   });
 
-  it("AutoPollOptions initialization With -1 'maxInitWaitTimeSeconds' ShouldThrowError", () => {
-    expect(() => {
-      new AutoPollOptions("APIKEY", "common", "1.0.0", { maxInitWaitTimeSeconds: -1 }, null);
-    }).to.throw("Invalid 'maxInitWaitTimeSeconds' value");
-  });
-
   it("AutoPollOptions initialization With NaN 'maxInitWaitTimeSeconds' ShouldThrowError", () => {
     const myConfig = new Map();
     myConfig.set("maxInitWaitTimeSeconds", NaN);
@@ -320,6 +314,90 @@ describe("Options", () => {
     const options: ManualPollOptions = new ManualPollOptions("APIKEY", "common", "1.0.0", {}, null);
     assert.equal("common/m-1.0.0", options.clientVersion);
   });
+
+  for (const [pollIntervalSecs, isValid] of [
+    [-Infinity, false],
+    [-1, false],
+    [0, false],
+    [0.999, false],
+    [1, true],
+    [2 ** 31 / 1000 - 1, true],
+    [2 ** 31 / 1000, false],
+    [Infinity, false],
+    [NaN, false],
+    ["1", false],
+  ]) {
+    it(`AutoPollOptions initialization - pollIntervalSeconds range validation works - ${pollIntervalSecs} (${typeof pollIntervalSecs})`, () => {
+      const action = () => new AutoPollOptions("SDKKEY", "SDKTYPE", "SDKVERSION", {
+        pollIntervalSeconds: pollIntervalSecs as unknown as number
+      });
+
+      if (isValid) {
+        action();
+      }
+      else {
+        let ex: any;
+        try { action(); }
+        catch (err) { ex = err; }
+        assert.instanceOf(ex, Error);
+      }
+    });
+  }
+
+  for (const [maxInitWaitTimeSecs, isValid] of [
+    [-Infinity, true],
+    [-1, true],
+    [2 ** 31 / 1000 - 1, true],
+    [2 ** 31 / 1000, false],
+    [Infinity, false],
+    [NaN, false],
+    ["1", false],
+  ]) {
+    it(`AutoPollOptions initialization - maxInitWaitTimeSeconds range validation works - ${maxInitWaitTimeSecs} (${typeof maxInitWaitTimeSecs})`, () => {
+      const action = () => new AutoPollOptions("SDKKEY", "SDKTYPE", "SDKVERSION", {
+        maxInitWaitTimeSeconds: maxInitWaitTimeSecs as unknown as number
+      });
+
+      if (isValid) {
+        action();
+      }
+      else {
+        let ex: any;
+        try { action(); }
+        catch (err) { ex = err; }
+        assert.instanceOf(ex, Error);
+      }
+    });
+  }
+
+  for (const [cacheTimeToLiveSecs, isValid] of [
+    [-Infinity, false],
+    [-1, false],
+    [0, false],
+    [0.999, false],
+    [1, true],
+    [2 ** 31 - 1, true],
+    [2 ** 31, false],
+    [Infinity, false],
+    [NaN, false],
+    ["1", false],
+  ]) {
+    it(`LazyLoadOptions initialization - cacheTimeToLiveSeconds range validation works - ${cacheTimeToLiveSecs} (${typeof cacheTimeToLiveSecs})`, () => {
+      const action = () => new LazyLoadOptions("SDKKEY", "SDKTYPE", "SDKVERSION", {
+        cacheTimeToLiveSeconds: cacheTimeToLiveSecs as unknown as number
+      });
+
+      if (isValid) {
+        action();
+      }
+      else {
+        let ex: any;
+        try { action(); }
+        catch (err) { ex = err; }
+        assert.instanceOf(ex, Error);
+      }
+    });
+  }
 });
 
 class FakeOptionsBase extends OptionsBase { }


### PR DESCRIPTION
### Describe the purpose of your pull request

Revise the ranges in which `IAutoPollOptions.pollIntervalSeconds`, `IAutoPollOptions.maxInitWaitTimeSeconds` and `ILazyLoadOptions.cacheTimeToLiveSeconds` are valid.

Also, fixes a slight "... is not a function" bug and makes infinite init wait possible in `AutoPollConfigService`.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
