### PR TITLE
Fix always firing onConfigChanged hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-common",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-common",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-common",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "ConfigCat is a configuration as a service that lets you manage your features and configurations without actually deploying new code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -99,16 +99,15 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     const success = fetchResult.status === FetchStatus.Fetched;
     if (success
         || fetchResult.config.timestamp > latestConfig.timestamp && (!fetchResult.config.isEmpty || latestConfig.isEmpty)) {
+      await this.options.cache.set(this.cacheKey, fetchResult.config);
+
+      this.onConfigUpdated(fetchResult.config);
+
+      if (success && fetchResult.config.configJson != latestConfig.configJson) {
+        this.onConfigChanged(fetchResult.config);
+      }
 
       latestConfig = fetchResult.config;
-
-      await this.options.cache.set(this.cacheKey, latestConfig);
-
-      this.onConfigUpdated(latestConfig);
-
-      if (success) {
-        this.onConfigChanged(latestConfig);
-      }
     }
 
     return [fetchResult, latestConfig];

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -103,7 +103,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
       this.onConfigUpdated(fetchResult.config);
 
-      if (success && fetchResult.config.configJson != latestConfig.configJson) {
+      if (success && (fetchResult.config.httpETag != latestConfig.httpETag || fetchResult.config.configJson != latestConfig.configJson)) {
         this.onConfigChanged(fetchResult.config);
       }
 

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -496,6 +496,24 @@ describe("ConfigCatClient", () => {
     assert.equal(configChangedEventCount, 3);
   });
 
+  it("Initialization With AutoPollOptions - config doesn't change - should fire configChanged only once", async () => {
+
+    const configCatKernel: FakeConfigCatKernel = { configFetcher: new FakeConfigFetcher(), sdkType: "common", sdkVersion: "1.0.0" };
+    let configChangedEventCount = 0;
+    const pollIntervalSeconds = 1;
+    const userOptions: IAutoPollOptions = {
+      logger: null,
+      pollIntervalSeconds,
+      setupHooks: hooks => hooks.on("configChanged", () => configChangedEventCount++)
+    };
+    const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", userOptions, null);
+    new ConfigCatClient(options, configCatKernel);
+
+    await delay(2.5 * pollIntervalSeconds * 1000);
+
+    assert.equal(configChangedEventCount, 1);
+  });
+
   it("Initialization With AutoPollOptions - with maxInitWaitTimeSeconds - getValueAsync should wait", async () => {
 
     const maxInitWaitTimeSeconds = 2;


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR fixes an issue that the `configChanged` hook is emitted in browser environments even when the downloaded config JSON isn't changed.
Part of the issue is that we get `200` response from the browser even when the server responds with `304` due to the `Cache-Control: max-age=0, must revalidate` header we introduced to bypass unnecessary `OPTIONS` requests.

### Related issues (only if applicable)

[JS-SDK issue](https://github.com/configcat/js-sdk/issues/81)

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
