### PR TITLE
Synchronous getValue/getValueDetails

### DIFF
--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -35,8 +35,7 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
 
       this.initialization.then(() => {
         if (!this.disposed) {
-          options.hooks.emit("clientReady");
-          options.hooks.emit("clientReadyWithState", this.getReadyState());
+          options.signalReadyState(this.getReadyState(options.cache.getInMemory()));
         }
       });
 
@@ -47,8 +46,7 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
     else {
       this.initialized = true;
       this.initialization = Promise.resolve();
-      options.hooks.emit("clientReady");
-      options.hooks.emit("clientReadyWithState", this.getReadyState())
+      options.signalReadyState(this.getReadyState(options.cache.getInMemory()));
     }
 
     if (!options.offline) {
@@ -175,9 +173,7 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
     this.timerId = setTimeout(d => this.refreshWorkerLogic(d), delayMs, delayMs);
   }
 
-  private getReadyState(): ClientReadyState {
-    const flagData = this.options.cache.getInMemory();
-
+  protected getReadyState(flagData: ProjectConfig): ClientReadyState {
     if (flagData.isEmpty) {
       return ClientReadyState.NoFlagData;
     }

--- a/src/ConfigCatCache.ts
+++ b/src/ConfigCatCache.ts
@@ -22,6 +22,8 @@ export interface IConfigCache {
   set(key: string, config: ProjectConfig): Promise<void> | void;
 
   get(key: string): Promise<ProjectConfig> | ProjectConfig;
+
+  getInMemory(): ProjectConfig
 }
 
 export class InMemoryConfigCache implements IConfigCache {
@@ -32,6 +34,10 @@ export class InMemoryConfigCache implements IConfigCache {
   }
 
   get(_key: string): ProjectConfig {
+    return this.cachedConfig;
+  }
+
+  getInMemory(): ProjectConfig {
     return this.cachedConfig;
   }
 }
@@ -81,6 +87,10 @@ export class ExternalConfigCache implements IConfigCache {
       this.logger.configServiceCacheReadError(err);
     }
 
+    return this.cachedConfig;
+  }
+
+  getInMemory(): ProjectConfig {
     return this.cachedConfig;
   }
 }

--- a/src/ConfigCatCache.ts
+++ b/src/ConfigCatCache.ts
@@ -23,7 +23,7 @@ export interface IConfigCache {
 
   get(key: string): Promise<ProjectConfig> | ProjectConfig;
 
-  getInMemory(): ProjectConfig
+  getInMemory(): ProjectConfig;
 }
 
 export class InMemoryConfigCache implements IConfigCache {

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -8,11 +8,12 @@ import type { IConfigService } from "./ConfigServiceBase";
 import { RefreshResult } from "./ConfigServiceBase";
 import type { IEventEmitter } from "./EventEmitter";
 import { OverrideBehaviour } from "./FlagOverrides";
-import { ClientReadyState, HookEvents, Hooks, IProvidesHooks } from "./Hooks";
+import type { HookEvents, Hooks, IProvidesHooks } from "./Hooks";
+import { ClientReadyState } from "./Hooks";
 import { LazyLoadConfigService } from "./LazyLoadConfigService";
 import { ManualPollConfigService } from "./ManualPollConfigService";
 import { getWeakRefStub, isWeakRefAvailable } from "./Polyfills";
-import type { ProjectConfig, RolloutPercentageItem, RolloutRule, Setting, SettingValue } from "./ProjectConfig";
+import type { IConfig, ProjectConfig, RolloutPercentageItem, RolloutRule, Setting, SettingValue } from "./ProjectConfig";
 import type { IEvaluationDetails, IRolloutEvaluator, SettingTypeOf, User } from "./RolloutEvaluator";
 import { RolloutEvaluator, checkSettingsAvailable, evaluate, evaluateAll, evaluationDetailsFromDefaultValue, getTimestampAsDate, isAllowedValue } from "./RolloutEvaluator";
 import { errorToString } from "./Utils";
@@ -35,20 +36,6 @@ export interface IConfigCatClient extends IProvidesHooks {
   getValueAsync<T extends SettingValue>(key: string, defaultValue: T, user?: User): Promise<SettingTypeOf<T>>;
 
   /**
-   * Returns the value of a feature flag or setting identified by `key` synchronously from the cache.
-   * @remarks
-   * It is important to provide an argument for the `defaultValue` parameter that matches the type of the feature flag or setting you are evaluating.
-   * Please refer to {@link https://configcat.com/docs/sdk-reference/js/#setting-type-mapping | this table} for the corresponding types.
-   * @param key Key of the feature flag or setting.
-   * @param defaultValue In case of failure, this value will be returned. Only the following types are allowed: `string`, `boolean`, `number`, `null` and `undefined`.
-   * @param user The User Object to use for evaluating targeting rules and percentage options.
-   * @returns The cached value of the feature flag or setting.
-   * @throws {Error} `key` is empty.
-   * @throws {TypeError} `defaultValue` is not of an allowed type.
-   */
-  getValue<T extends SettingValue>(key: string, defaultValue: T, user?: User): SettingTypeOf<T>;
-
-  /**
    * Returns the value along with evaluation details of a feature flag or setting identified by `key`.
    * @remarks
    * It is important to provide an argument for the `defaultValue` parameter that matches the type of the feature flag or setting you are evaluating.
@@ -61,20 +48,6 @@ export interface IConfigCatClient extends IProvidesHooks {
    * @throws {TypeError} `defaultValue` is not of an allowed type.
    */
   getValueDetailsAsync<T extends SettingValue>(key: string, defaultValue: T, user?: User): Promise<IEvaluationDetails<SettingTypeOf<T>>>;
-
-  /**
-   * Returns the value along with evaluation details of a feature flag or setting identified by `key` synchronously from the cache.
-   * @remarks
-   * It is important to provide an argument for the `defaultValue` parameter that matches the type of the feature flag or setting you are evaluating.
-   * Please refer to {@link https://configcat.com/docs/sdk-reference/js/#setting-type-mapping | this table} for the corresponding types.
-   * @param key Key of the feature flag or setting.
-   * @param defaultValue In case of failure, this value will be returned. Only the following types are allowed: `string`, `boolean`, `number`, `null` and `undefined`.
-   * @param user The User Object to use for evaluating targeting rules and percentage options.
-   * @returns The cached value along with the details of evaluation of the feature flag or setting.
-   * @throws {Error} `key` is empty.
-   * @throws {TypeError} `defaultValue` is not of an allowed type.
-   */
-  getValueDetails<T extends SettingValue>(key: string, defaultValue: T, user?: User): IEvaluationDetails<SettingTypeOf<T>>;
 
   /**
    * Returns all setting keys.
@@ -118,6 +91,12 @@ export interface IConfigCatClient extends IProvidesHooks {
   waitForReady(): Promise<ClientReadyState>;
 
   /**
+   * Captures the current state of the client.
+   * The resulting snapshot can be used to synchronously evaluate feature flags and settings based on the captured state.
+   */
+  snapshot(): IConfigCatClientSnapshot;
+
+  /**
    * Sets the default user.
    * @param defaultUser The default User Object to use for evaluating targeting rules and percentage options.
    */
@@ -147,6 +126,46 @@ export interface IConfigCatClient extends IProvidesHooks {
    * Releases all resources used by the client.
    */
   dispose(): void;
+}
+
+/** Represents the state of `IConfigCatClient` captured at a specific point in time. */
+export interface IConfigCatClientSnapshot {
+  /** The latest config which has been fetched from the remote server. */
+  readonly fetchedConfig: IConfig | null;
+
+  /**
+   * Returns the available setting keys.
+   * (In case the client is configured to use flag override, this will also include the keys provided by the flag override).
+   */
+  getAllKeys(): ReadonlyArray<string>;
+
+  /**
+   * Returns the value of a feature flag or setting identified by `key` synchronously, based on the snapshot.
+   * @remarks
+   * It is important to provide an argument for the `defaultValue` parameter that matches the type of the feature flag or setting you are evaluating.
+   * Please refer to {@link https://configcat.com/docs/sdk-reference/js/#setting-type-mapping | this table} for the corresponding types.
+   * @param key Key of the feature flag or setting.
+   * @param defaultValue In case of failure, this value will be returned. Only the following types are allowed: `string`, `boolean`, `number`, `null` and `undefined`.
+   * @param user The User Object to use for evaluating targeting rules and percentage options.
+   * @returns The cached value of the feature flag or setting.
+   * @throws {Error} `key` is empty.
+   * @throws {TypeError} `defaultValue` is not of an allowed type.
+   */
+  getValue<T extends SettingValue>(key: string, defaultValue: T, user?: User): SettingTypeOf<T>;
+
+  /**
+ * Returns the value along with evaluation details of a feature flag or setting identified by `key` synchronously, based on the snapshot.
+ * @remarks
+ * It is important to provide an argument for the `defaultValue` parameter that matches the type of the feature flag or setting you are evaluating.
+ * Please refer to {@link https://configcat.com/docs/sdk-reference/js/#setting-type-mapping | this table} for the corresponding types.
+ * @param key Key of the feature flag or setting.
+ * @param defaultValue In case of failure, this value will be returned. Only the following types are allowed: `string`, `boolean`, `number`, `null` and `undefined`.
+ * @param user The User Object to use for evaluating targeting rules and percentage options.
+ * @returns The cached value along with the details of evaluation of the feature flag or setting.
+ * @throws {Error} `key` is empty.
+ * @throws {TypeError} `defaultValue` is not of an allowed type.
+ */
+  getValueDetails<T extends SettingValue>(key: string, defaultValue: T, user?: User): IEvaluationDetails<SettingTypeOf<T>>;
 }
 
 export interface IConfigCatKernel {
@@ -270,13 +289,14 @@ export class ConfigCatClient implements IConfigCatClient {
     this.evaluator = new RolloutEvaluator(options.logger);
 
     if (options.flagOverrides?.behaviour !== OverrideBehaviour.LocalOnly) {
-      this.configService = options instanceof AutoPollOptions ? new AutoPollConfigService(configCatKernel.configFetcher, options) :
-        options instanceof ManualPollOptions ? new  ManualPollConfigService(configCatKernel.configFetcher, options) :
-        options instanceof LazyLoadOptions ? new  LazyLoadConfigService(configCatKernel.configFetcher, options) :
+      this.configService =
+        options instanceof AutoPollOptions ? new AutoPollConfigService(configCatKernel.configFetcher, options) :
+        options instanceof ManualPollOptions ? new ManualPollConfigService(configCatKernel.configFetcher, options) :
+        options instanceof LazyLoadOptions ? new LazyLoadConfigService(configCatKernel.configFetcher, options) :
         (() => { throw new Error("Invalid 'options' value"); })();
     }
     else {
-      this.options.signalReadyState(ClientReadyState.HasLocalOverrideFlagDataOnly);
+      this.options.hooks.emit("clientReady", ClientReadyState.HasLocalOverrideFlagDataOnly);
     }
 
     this.suppressFinalize = registerForFinalization(this, { sdkKey: options.apiKey, cacheToken, configService: this.configService, logger: options.logger });
@@ -358,31 +378,6 @@ export class ConfigCatClient implements IConfigCatClient {
     return value;
   }
 
-  getValue<T extends SettingValue>(key: string, defaultValue: T, user?: User): SettingTypeOf<T> {
-    this.options.logger.debug("getValue() called.");
-
-    validateKey(key);
-    ensureAllowedDefaultValue(defaultValue);
-
-    let value: SettingTypeOf<T>, evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>;
-    let remoteConfig: ProjectConfig | null = null;
-    user ??= this.defaultUser;
-    try {
-      let settings: { [name: string]: Setting } | null;
-      [settings, remoteConfig] = this.getSettingsFromCache();
-      evaluationDetails = evaluate(this.evaluator, settings, key, defaultValue, user, remoteConfig, this.options.logger);
-      value = evaluationDetails.value;
-    }
-    catch (err) {
-      this.options.logger.settingEvaluationErrorSingle("getValue", key, "defaultValue", defaultValue, err);
-      evaluationDetails = evaluationDetailsFromDefaultValue(key, defaultValue, getTimestampAsDate(remoteConfig), user, errorToString(err), err);
-      value = defaultValue as SettingTypeOf<T>;
-    }
-
-    this.options.hooks.emit("flagEvaluated", evaluationDetails);
-    return value;
-  }
-
   async getValueDetailsAsync<T extends SettingValue>(key: string, defaultValue: T, user?: User): Promise<IEvaluationDetails<SettingTypeOf<T>>> {
     this.options.logger.debug("getValueDetailsAsync() called.");
 
@@ -399,29 +394,6 @@ export class ConfigCatClient implements IConfigCatClient {
     }
     catch (err) {
       this.options.logger.settingEvaluationErrorSingle("getValueDetailsAsync", key, "defaultValue", defaultValue, err);
-      evaluationDetails = evaluationDetailsFromDefaultValue(key, defaultValue, getTimestampAsDate(remoteConfig), user, errorToString(err), err);
-    }
-
-    this.options.hooks.emit("flagEvaluated", evaluationDetails);
-    return evaluationDetails;
-  }
-
-  getValueDetails<T extends SettingValue>(key: string, defaultValue: T, user?: User): IEvaluationDetails<SettingTypeOf<T>> {
-    this.options.logger.debug("getValueDetails() called.");
-
-    validateKey(key);
-    ensureAllowedDefaultValue(defaultValue);
-
-    let evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>;
-    let remoteConfig: ProjectConfig | null = null;
-    user ??= this.defaultUser;
-    try {
-      let settings: { [name: string]: Setting } | null;
-      [settings, remoteConfig] = this.getSettingsFromCache();
-      evaluationDetails = evaluate(this.evaluator, settings, key, defaultValue, user, remoteConfig, this.options.logger);
-    }
-    catch (err) {
-      this.options.logger.settingEvaluationErrorSingle("getValueDetails", key, "defaultValue", defaultValue, err);
       evaluationDetails = evaluationDetailsFromDefaultValue(key, defaultValue, getTimestampAsDate(remoteConfig), user, errorToString(err), err);
     }
 
@@ -592,6 +564,34 @@ export class ConfigCatClient implements IConfigCatClient {
     return this.options.readyPromise;
   }
 
+  snapshot(): IConfigCatClientSnapshot {
+    const getRemoteConfig: () => SettingsWithRemoteConfig = () => {
+      const config = this.options.cache.getInMemory();
+      const settings = !config.isEmpty ? config.config!.settings : null;
+      return [settings, config];
+    };
+
+    let remoteSettings: { [name: string]: Setting } | null;
+    let remoteConfig: ProjectConfig | null;
+    const flagOverrides = this.options?.flagOverrides;
+    if (flagOverrides) {
+      const localSettings = flagOverrides.dataSource.getOverridesSync();
+      switch (flagOverrides.behaviour) {
+        case OverrideBehaviour.LocalOnly:
+          return new Snapshot(localSettings, null, this);
+        case OverrideBehaviour.LocalOverRemote:
+          [remoteSettings, remoteConfig] = getRemoteConfig();
+          return new Snapshot({ ...(remoteSettings ?? {}), ...localSettings }, remoteConfig, this);
+        case OverrideBehaviour.RemoteOverLocal:
+          [remoteSettings, remoteConfig] = getRemoteConfig();
+          return new Snapshot({ ...localSettings, ...(remoteSettings ?? {}) }, remoteConfig, this);
+      }
+    }
+
+    [remoteSettings, remoteConfig] = getRemoteConfig();
+    return new Snapshot(remoteSettings, remoteConfig, this);
+  }
+
   private async getSettingsAsync(): Promise<SettingsWithRemoteConfig> {
     this.options.logger.debug("getSettingsAsync() called.");
 
@@ -619,35 +619,6 @@ export class ConfigCatClient implements IConfigCatClient {
     }
 
     return await getRemoteConfigAsync();
-  }
-
-  private getSettingsFromCache(): SettingsWithRemoteConfig {
-    this.options.logger.debug("getSettingsFromCache() called.");
-
-    const getRemoteConfig: () => SettingsWithRemoteConfig = () => {
-      const config = this.options.cache.getInMemory();
-      const settings = !config.isEmpty ? config.config!.settings : null;
-      return [settings, config];
-    };
-
-    const flagOverrides = this.options?.flagOverrides;
-    if (flagOverrides) {
-      let remoteSettings: { [name: string]: Setting } | null;
-      let remoteConfig: ProjectConfig | null;
-      const localSettings = flagOverrides.dataSource.getOverridesSync();
-      switch (flagOverrides.behaviour) {
-        case OverrideBehaviour.LocalOnly:
-          return [localSettings, null];
-        case OverrideBehaviour.LocalOverRemote:
-          [remoteSettings, remoteConfig] = getRemoteConfig();
-          return [{ ...(remoteSettings ?? {}), ...localSettings }, remoteConfig];
-        case OverrideBehaviour.RemoteOverLocal:
-          [remoteSettings, remoteConfig] = getRemoteConfig();
-          return [{ ...localSettings, ...(remoteSettings ?? {}) }, remoteConfig];
-      }
-    }
-
-    return getRemoteConfig();
   }
 
   /** @inheritdoc */
@@ -693,6 +664,71 @@ export class ConfigCatClient implements IConfigCatClient {
   /** @inheritdoc */
   eventNames(): Array<keyof HookEvents> {
     return this.options.hooks.eventNames();
+  }
+}
+
+class Snapshot implements IConfigCatClientSnapshot {
+  private readonly defaultUser: User | undefined;
+  private readonly evaluator: IRolloutEvaluator;
+  private readonly options: ConfigCatClientOptions;
+
+  constructor(
+    private readonly mergedSettings: { [name: string]: Setting } | null,
+    private readonly remoteConfig: ProjectConfig | null,
+    client: ConfigCatClient) {
+
+    this.defaultUser = client["defaultUser"];
+    this.evaluator = client["evaluator"];
+    this.options = client["options"];
+  }
+
+  get fetchedConfig() {
+    const config = this.remoteConfig;
+    return config && !config.isEmpty ? config.config! : null;
+  }
+
+  getAllKeys() { return this.mergedSettings ? Object.keys(this.mergedSettings) : []; }
+
+  getValue<T extends SettingValue>(key: string, defaultValue: T, user?: User): SettingTypeOf<T> {
+    this.options.logger.debug("Snapshot.getValue() called.");
+
+    validateKey(key);
+    ensureAllowedDefaultValue(defaultValue);
+
+    let value: SettingTypeOf<T>, evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>;
+    user ??= this.defaultUser;
+    try {
+      evaluationDetails = evaluate(this.evaluator, this.mergedSettings, key, defaultValue, user, this.remoteConfig, this.options.logger);
+      value = evaluationDetails.value;
+    }
+    catch (err) {
+      this.options.logger.settingEvaluationErrorSingle("Snapshot.getValue", key, "defaultValue", defaultValue, err);
+      evaluationDetails = evaluationDetailsFromDefaultValue(key, defaultValue, getTimestampAsDate(this.remoteConfig), user, errorToString(err), err);
+      value = defaultValue as SettingTypeOf<T>;
+    }
+
+    this.options.hooks.emit("flagEvaluated", evaluationDetails);
+    return value;
+  }
+
+  getValueDetails<T extends SettingValue>(key: string, defaultValue: T, user?: User): IEvaluationDetails<SettingTypeOf<T>> {
+    this.options.logger.debug("Snapshot.getValueDetails() called.");
+
+    validateKey(key);
+    ensureAllowedDefaultValue(defaultValue);
+
+    let evaluationDetails: IEvaluationDetails<SettingTypeOf<T>>;
+    user ??= this.defaultUser;
+    try {
+      evaluationDetails = evaluate(this.evaluator, this.mergedSettings, key, defaultValue, user, this.remoteConfig, this.options.logger);
+    }
+    catch (err) {
+      this.options.logger.settingEvaluationErrorSingle("Snapshot.getValueDetails", key, "defaultValue", defaultValue, err);
+      evaluationDetails = evaluationDetailsFromDefaultValue(key, defaultValue, getTimestampAsDate(this.remoteConfig), user, errorToString(err), err);
+    }
+
+    this.options.hooks.emit("flagEvaluated", evaluationDetails);
+    return evaluationDetails;
   }
 }
 

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -181,7 +181,7 @@ export abstract class OptionsBase {
 
     const eventEmitter = eventEmitterFactory?.() ?? new DefaultEventEmitter();
     this.hooks = new Hooks(eventEmitter);
-    this.readyPromise = new Promise(resolve => eventEmitter.once("clientReadyWithState", resolve));
+    this.readyPromise = new Promise(resolve => this.hooks.once("clientReady", resolve));
 
     let logger: IConfigCatLogger | null | undefined;
     let cache: IConfigCatCache | null | undefined;
@@ -235,11 +235,6 @@ export abstract class OptionsBase {
 
   getCacheKey(): string {
     return sha1(`${this.apiKey}_${OptionsBase.configFileName}_${ProjectConfig.serializationFormatVersion}`);
-  }
-
-  signalReadyState(state: ClientReadyState) {
-    this.hooks.emit("clientReady");
-    this.hooks.emit("clientReadyWithState", state);
   }
 }
 

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -236,6 +236,11 @@ export abstract class OptionsBase {
   getCacheKey(): string {
     return sha1(`${this.apiKey}_${OptionsBase.configFileName}_${ProjectConfig.serializationFormatVersion}`);
   }
+
+  signalReadyState(state: ClientReadyState) {
+    this.hooks.emit("clientReady");
+    this.hooks.emit("clientReadyWithState", state);
+  }
 }
 
 export class AutoPollOptions extends OptionsBase {

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -5,7 +5,7 @@ import { ConfigCatConsoleLogger, LoggerWrapper } from "./ConfigCatLogger";
 import { DefaultEventEmitter } from "./DefaultEventEmitter";
 import type { IEventEmitter } from "./EventEmitter";
 import type { FlagOverrides } from "./FlagOverrides";
-import type { IProvidesHooks } from "./Hooks";
+import type { ClientReadyState, IProvidesHooks } from "./Hooks";
 import { Hooks } from "./Hooks";
 import { ProjectConfig } from "./ProjectConfig";
 import type { User } from "./RolloutEvaluator";
@@ -156,6 +156,8 @@ export abstract class OptionsBase {
 
   hooks: Hooks;
 
+  readyPromise: Promise<ClientReadyState>;
+
   constructor(apiKey: string, clientVersion: string, options?: IOptions | null,
     defaultCacheFactory?: ((options: OptionsBase) => IConfigCache) | null,
     eventEmitterFactory?: (() => IEventEmitter) | null) {
@@ -179,6 +181,7 @@ export abstract class OptionsBase {
 
     const eventEmitter = eventEmitterFactory?.() ?? new DefaultEventEmitter();
     this.hooks = new Hooks(eventEmitter);
+    this.readyPromise = new Promise(resolve => eventEmitter.once("clientReadyWithState", resolve));
 
     let logger: IConfigCatLogger | null | undefined;
     let cache: IConfigCatCache | null | undefined;

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -1,6 +1,7 @@
 import type { OptionsBase } from "./ConfigCatClientOptions";
 import type { FetchErrorCauses, IConfigFetcher, IFetchResponse } from "./ConfigFetcher";
 import { FetchError, FetchResult, FetchStatus } from "./ConfigFetcher";
+import { ClientReadyState } from "./Hooks";
 import { Config, ProjectConfig, RedirectMode } from "./ProjectConfig";
 
 /** Contains the result of an `IConfigCatClient.forceRefresh` or `IConfigCatClient.forceRefreshAsync` operation. */
@@ -280,5 +281,12 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     else if (this.disposed) {
       this.options.logger.configServiceMethodHasNoEffectDueToDisposedClient("setOffline");
     }
+  }
+
+  protected abstract getReadyState(flagData: ProjectConfig): ClientReadyState;
+
+  protected async syncUpWithCache() {
+    const flagData = await this.options.cache.get(this.cacheKey);
+    this.options.signalReadyState(this.getReadyState(flagData));
   }
 }

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -1,7 +1,7 @@
 import type { OptionsBase } from "./ConfigCatClientOptions";
 import type { FetchErrorCauses, IConfigFetcher, IFetchResponse } from "./ConfigFetcher";
 import { FetchError, FetchResult, FetchStatus } from "./ConfigFetcher";
-import { ClientReadyState } from "./Hooks";
+import type { ClientReadyState } from "./Hooks";
 import { Config, ProjectConfig, RedirectMode } from "./ProjectConfig";
 
 /** Contains the result of an `IConfigCatClient.forceRefresh` or `IConfigCatClient.forceRefreshAsync` operation. */
@@ -283,10 +283,10 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     }
   }
 
-  protected abstract getReadyState(flagData: ProjectConfig): ClientReadyState;
+  protected abstract getReadyState(cachedConfig: ProjectConfig): ClientReadyState;
 
-  protected async syncUpWithCache() {
-    const flagData = await this.options.cache.get(this.cacheKey);
-    this.options.signalReadyState(this.getReadyState(flagData));
+  protected async syncUpWithCache(): Promise<void> {
+    const cachedConfig = await this.options.cache.get(this.cacheKey);
+    this.options.hooks.emit("clientReady", this.getReadyState(cachedConfig));
   }
 }

--- a/src/FlagOverrides.ts
+++ b/src/FlagOverrides.ts
@@ -26,6 +26,8 @@ export enum OverrideBehaviour {
 
 export interface IOverrideDataSource {
   getOverrides(): Promise<{ [name: string]: Setting }>;
+
+  getOverridesSync(): { [name: string]: Setting };
 }
 
 export class MapOverrideDataSource implements IOverrideDataSource {
@@ -39,6 +41,10 @@ export class MapOverrideDataSource implements IOverrideDataSource {
 
   getOverrides(): Promise<{ [name: string]: Setting }> {
     return Promise.resolve(this.map);
+  }
+
+  getOverridesSync(): { [name: string]: Setting } {
+    return this.map;
   }
 }
 

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -3,10 +3,19 @@ import { NullEventEmitter } from "./EventEmitter";
 import type { IConfig } from "./ProjectConfig";
 import type { IEvaluationDetails } from "./RolloutEvaluator";
 
+/** Contains the initialization state of `ConfigCatClient`. */
+export enum ClientReadyState {
+  NoFlagData,
+  HasCachedFlagDataOnly,
+  HasUpToDateFlagData,
+}
+
 /** Hooks (events) that can be emitted by `ConfigCatClient`. */
 export type HookEvents = {
   /** Occurs when the client is ready to provide the actual value of feature flags or settings. */
   clientReady: [];
+  /** Occurs when the client is ready to provide the actual value of feature flags or settings. */
+  clientReadyWithState: [state: ClientReadyState];
   /** Occurs after the value of a feature flag of setting has been evaluated. */
   flagEvaluated: [evaluationDetails: IEvaluationDetails];
   /** Occurs after the locally cached config has been updated. */

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -6,6 +6,7 @@ import type { IEvaluationDetails } from "./RolloutEvaluator";
 /** Contains the initialization state of `ConfigCatClient`. */
 export enum ClientReadyState {
   NoFlagData,
+  HasLocalOverrideFlagDataOnly,
   HasCachedFlagDataOnly,
   HasUpToDateFlagData,
 }

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -14,9 +14,7 @@ export enum ClientReadyState {
 /** Hooks (events) that can be emitted by `ConfigCatClient`. */
 export type HookEvents = {
   /** Occurs when the client is ready to provide the actual value of feature flags or settings. */
-  clientReady: [];
-  /** Occurs when the client is ready to provide the actual value of feature flags or settings. */
-  clientReadyWithState: [state: ClientReadyState];
+  clientReady: [state: ClientReadyState];
   /** Occurs after the value of a feature flag of setting has been evaluated. */
   flagEvaluated: [evaluationDetails: IEvaluationDetails];
   /** Occurs after the locally cached config has been updated. */

--- a/src/LazyLoadConfigService.ts
+++ b/src/LazyLoadConfigService.ts
@@ -47,12 +47,12 @@ export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> im
     return super.refreshConfigAsync();
   }
 
-  protected getReadyState(flagData: ProjectConfig): ClientReadyState {
-    if (flagData.isEmpty) {
+  protected getReadyState(cachedConfig: ProjectConfig): ClientReadyState {
+    if (cachedConfig.isEmpty) {
       return ClientReadyState.NoFlagData;
     }
-    
-    if (flagData.isExpired(this.cacheTimeToLiveMs)) {
+
+    if (cachedConfig.isExpired(this.cacheTimeToLiveMs)) {
       return ClientReadyState.HasCachedFlagDataOnly;
     }
 

--- a/src/LazyLoadConfigService.ts
+++ b/src/LazyLoadConfigService.ts
@@ -3,6 +3,7 @@ import type { LoggerWrapper } from "./ConfigCatLogger";
 import type { IConfigFetcher } from "./ConfigFetcher";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
 import { ConfigServiceBase } from "./ConfigServiceBase";
+import { ClientReadyState } from "./Hooks";
 import type { ProjectConfig } from "./ProjectConfig";
 
 export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> implements IConfigService {
@@ -16,6 +17,8 @@ export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> im
     this.cacheTimeToLiveMs = options.cacheTimeToLiveSeconds * 1000;
 
     options.hooks.emit("clientReady");
+    // lazy load gets the flag data at the first getValue() call.
+    options.hooks.emit("clientReadyWithState", ClientReadyState.NoFlagData);
   }
 
   async getConfig(): Promise<ProjectConfig> {

--- a/src/ManualPollConfigService.ts
+++ b/src/ManualPollConfigService.ts
@@ -14,8 +14,8 @@ export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions
     super.syncUpWithCache();
   }
 
-  protected getReadyState(flagData: ProjectConfig): ClientReadyState {
-    if (flagData.isEmpty) {
+  protected getReadyState(cachedConfig: ProjectConfig): ClientReadyState {
+    if (cachedConfig.isEmpty) {
       return ClientReadyState.NoFlagData;
     }
 

--- a/src/ManualPollConfigService.ts
+++ b/src/ManualPollConfigService.ts
@@ -11,9 +11,15 @@ export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions
 
     super(configFetcher, options);
 
-    options.hooks.emit("clientReady");
-    // manual poll needs at least one force refresh to get flag data.
-    options.hooks.emit("clientReadyWithState", ClientReadyState.NoFlagData);
+    super.syncUpWithCache();
+  }
+
+  protected getReadyState(flagData: ProjectConfig): ClientReadyState {
+    if (flagData.isEmpty) {
+      return ClientReadyState.NoFlagData;
+    }
+
+    return ClientReadyState.HasCachedFlagDataOnly;
   }
 
   async getConfig(): Promise<ProjectConfig> {

--- a/src/ManualPollConfigService.ts
+++ b/src/ManualPollConfigService.ts
@@ -2,6 +2,7 @@ import type { ManualPollOptions } from "./ConfigCatClientOptions";
 import type { IConfigFetcher } from "./ConfigFetcher";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
 import { ConfigServiceBase } from "./ConfigServiceBase";
+import { ClientReadyState } from "./Hooks";
 import type { ProjectConfig } from "./ProjectConfig";
 
 export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions> implements IConfigService {
@@ -11,10 +12,11 @@ export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions
     super(configFetcher, options);
 
     options.hooks.emit("clientReady");
+    // manual poll needs at least one force refresh to get flag data.
+    options.hooks.emit("clientReadyWithState", ClientReadyState.NoFlagData);
   }
 
   async getConfig(): Promise<ProjectConfig> {
-
     this.options.logger.debug("ManualPollService.getConfig() called.");
     return await this.options.cache.get(this.cacheKey);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,8 @@ export { SettingType, Comparator } from "./ProjectConfig";
 
 export type { IConfigCatClient };
 
+export type { IConfigCatClientSnapshot } from "./ConfigCatClient";
+
 export { SettingKeyValue } from "./ConfigCatClient";
 
 export type { IEvaluationDetails, SettingTypeOf } from "./RolloutEvaluator";

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,3 +99,5 @@ export { OverrideBehaviour } from "./FlagOverrides";
 export { RefreshResult } from "./ConfigServiceBase";
 
 export type { IProvidesHooks, HookEvents } from "./Hooks";
+
+export { ClientReadyState } from "./Hooks";

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -409,7 +409,7 @@ class FakeCache implements IConfigCache {
     throw new Error("Method not implemented.");
   }
   getInMemory(): ProjectConfig {
-    throw new Error("Method not implemented.");    
+    throw new Error("Method not implemented.");
   }
 }
 

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -408,6 +408,9 @@ class FakeCache implements IConfigCache {
   get(key: string): ProjectConfig {
     throw new Error("Method not implemented.");
   }
+  getInMemory(): ProjectConfig {
+    throw new Error("Method not implemented.");    
+  }
 }
 
 class FakeExternalCache implements IConfigCatCache {

--- a/test/DataGovernanceTests.ts
+++ b/test/DataGovernanceTests.ts
@@ -304,7 +304,7 @@ export class FakeConfigServiceBase extends ConfigServiceBase<FakeOptions> {
     return baseUrl + "/configuration-files/API_KEY/config_v5.json?sdk=" + this.options.clientVersion;
   }
 
-  protected getReadyState(flagData: ProjectConfig): ClientReadyState {
+  protected getReadyState(cachedConfig: ProjectConfig): ClientReadyState {
     throw new Error("Method not implemented.");
   }
 }

--- a/test/DataGovernanceTests.ts
+++ b/test/DataGovernanceTests.ts
@@ -4,6 +4,7 @@ import { DataGovernance, OptionsBase } from "../src/ConfigCatClientOptions";
 import { FetchResult, IConfigFetcher, IFetchResponse } from "../src/ConfigFetcher";
 import { ConfigServiceBase } from "../src/ConfigServiceBase";
 import { Config, ProjectConfig } from "../src/ProjectConfig";
+import { ClientReadyState } from "../src/Hooks";
 
 const globalUrl = "https://cdn-global.configcat.com";
 const euOnlyUrl = "https://cdn-eu.configcat.com";
@@ -301,5 +302,9 @@ export class FakeConfigServiceBase extends ConfigServiceBase<FakeOptions> {
 
   private getUrl(baseUrl: string) {
     return baseUrl + "/configuration-files/API_KEY/config_v5.json?sdk=" + this.options.clientVersion;
+  }
+
+  protected getReadyState(flagData: ProjectConfig): ClientReadyState {
+    throw new Error("Method not implemented.");
   }
 }

--- a/test/DataGovernanceTests.ts
+++ b/test/DataGovernanceTests.ts
@@ -3,8 +3,8 @@ import "mocha";
 import { DataGovernance, OptionsBase } from "../src/ConfigCatClientOptions";
 import { FetchResult, IConfigFetcher, IFetchResponse } from "../src/ConfigFetcher";
 import { ConfigServiceBase } from "../src/ConfigServiceBase";
-import { Config, ProjectConfig } from "../src/ProjectConfig";
 import { ClientReadyState } from "../src/Hooks";
+import { Config, ProjectConfig } from "../src/ProjectConfig";
 
 const globalUrl = "https://cdn-global.configcat.com";
 const euOnlyUrl = "https://cdn-eu.configcat.com";

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -1,4 +1,4 @@
-import { LogEventId } from "../../lib";
+import { IConfigCatCache, LogEventId } from "../../lib";
 import { IConfigCache } from "../../src/ConfigCatCache";
 import { IConfigCatKernel } from "../../src/ConfigCatClient";
 import { OptionsBase } from "../../src/ConfigCatClientOptions";
@@ -42,6 +42,28 @@ export class FakeCache implements IConfigCache {
   get(_key: string): Promise<ProjectConfig> | ProjectConfig {
     return this.cached;
   }
+
+  getInMemory(): ProjectConfig {
+    return this.cached;
+  }
+}
+
+export class FakeExternalCacheWithInitialData implements IConfigCatCache {
+  expirationDelta: number;
+
+  constructor(expirationDelta = 0) {
+    this.expirationDelta = expirationDelta;
+  }
+
+  set(key: string, value: string): void | Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  get(key: string): string | Promise<string | null | undefined> | null | undefined {
+    const cachedJson = '{"f": { "debug": { "v": true, "i": "abcdefgh", "t": 0, "p": [], "r": [] } } }';
+    const config = new ProjectConfig(cachedJson, JSON.parse(cachedJson), (new Date().getTime()) - this.expirationDelta, "\"ETAG\"");
+    return ProjectConfig.serialize(config);
+  }
+
 }
 
 export class FakeConfigFetcherBase implements IConfigFetcher {


### PR DESCRIPTION
### Describe the purpose of your pull request

Adds an API which makes it possible to synchronously evaluate feature flags/settings: consumers can create a snapshot of the client by `IConfigCatClient.snapshot()`, which captures the client's state (including the latest config fetched) at that point, then, using the returned object, they can execute synchronous evaluation operations.

Also adds a `state` parameter to the `clientReady` hook, by means of which consumers can get information about the initialization state of the client.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
