### PR TITLE
Enhance snapshot API + minor improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
       "request": "launch",
       "name": "Run tests",
       "cwd": "${workspaceRoot}",
+      "env": { "TS_NODE_PROJECT": "./tsconfig.mocha.json" },
       "runtimeArgs": [
         "--expose-gc"
       ],

--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -2,8 +2,7 @@ import type { AutoPollOptions } from "./ConfigCatClientOptions";
 import type { LoggerWrapper } from "./ConfigCatLogger";
 import type { IConfigFetcher } from "./ConfigFetcher";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
-import { ConfigServiceBase } from "./ConfigServiceBase";
-import { ClientReadyState } from "./Hooks";
+import { ClientCacheState, ConfigServiceBase } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
 import { delay } from "./Utils";
 
@@ -178,15 +177,15 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
     this.workerTimerId = setTimeout(d => this.refreshWorkerLogic(d), delayMs, delayMs);
   }
 
-  getCacheState(cachedConfig: ProjectConfig): ClientReadyState {
+  getCacheState(cachedConfig: ProjectConfig): ClientCacheState {
     if (cachedConfig.isEmpty) {
-      return ClientReadyState.NoFlagData;
+      return ClientCacheState.NoFlagData;
     }
 
     if (cachedConfig.isExpired(this.pollIntervalMs)) {
-      return ClientReadyState.HasCachedFlagDataOnly;
+      return ClientCacheState.HasCachedFlagDataOnly;
     }
 
-    return ClientReadyState.HasUpToDateFlagData;
+    return ClientCacheState.HasUpToDateFlagData;
   }
 }

--- a/src/ConfigCatCache.ts
+++ b/src/ConfigCatCache.ts
@@ -88,16 +88,15 @@ export class ExternalConfigCache implements IConfigCache {
 
       // Take the async path only when the IConfigCatCache.get operation is asynchronous.
       if (isPromiseLike(cacheGetResult)) {
-        return cacheGetResult.then(externalSerializedConfig => {
+        return (async (cacheGetPromise) => {
           try {
-            this.updateCachedConfig(externalSerializedConfig);
+            this.updateCachedConfig(await cacheGetPromise);
           }
           catch (err) {
             this.logger.configServiceCacheReadError(err);
           }
-
           return this.cachedConfig;
-        });
+        })(cacheGetResult);
       }
 
       // Otherwise, keep the code flow synchronous so the config services can sync up

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -129,7 +129,7 @@ export interface IConfigCatClient extends IProvidesHooks {
 
 /** Represents the state of `IConfigCatClient` captured at a specific point in time. */
 export interface IConfigCatClientSnapshot {
-  readonly clientCacheState: ClientCacheState;
+  readonly cacheState: ClientCacheState;
 
   /** The latest config which has been fetched from the remote server. */
   readonly fetchedConfig: IConfig | null;
@@ -682,12 +682,12 @@ class Snapshot implements IConfigCatClientSnapshot {
     this.defaultUser = client["defaultUser"];
     this.evaluator = client["evaluator"];
     this.options = client["options"];
-    this.clientCacheState = remoteConfig
+    this.cacheState = remoteConfig
       ? client["configService"]!.getCacheState(remoteConfig)
       : ClientCacheState.HasLocalOverrideFlagDataOnly;
   }
 
-  readonly clientCacheState: ClientCacheState;
+  readonly cacheState: ClientCacheState;
 
   get fetchedConfig() {
     const config = this.remoteConfig;

--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -130,6 +130,8 @@ export interface IConfigCatClient extends IProvidesHooks {
 
 /** Represents the state of `IConfigCatClient` captured at a specific point in time. */
 export interface IConfigCatClientSnapshot {
+  readonly clientCacheState: ClientReadyState;
+
   /** The latest config which has been fetched from the remote server. */
   readonly fetchedConfig: IConfig | null;
 
@@ -681,7 +683,12 @@ class Snapshot implements IConfigCatClientSnapshot {
     this.defaultUser = client["defaultUser"];
     this.evaluator = client["evaluator"];
     this.options = client["options"];
+    this.clientCacheState = remoteConfig
+      ? client["configService"]!.getCacheState(remoteConfig)
+      : ClientReadyState.HasLocalOverrideFlagDataOnly;
   }
+
+  readonly clientCacheState: ClientReadyState;
 
   get fetchedConfig() {
     const config = this.remoteConfig;

--- a/src/ConfigCatClientOptions.ts
+++ b/src/ConfigCatClientOptions.ts
@@ -2,10 +2,11 @@ import type { IConfigCache, IConfigCatCache } from "./ConfigCatCache";
 import { ExternalConfigCache, InMemoryConfigCache } from "./ConfigCatCache";
 import type { IConfigCatLogger } from "./ConfigCatLogger";
 import { ConfigCatConsoleLogger, LoggerWrapper } from "./ConfigCatLogger";
+import type { ClientCacheState } from "./ConfigServiceBase";
 import { DefaultEventEmitter } from "./DefaultEventEmitter";
 import type { IEventEmitter } from "./EventEmitter";
 import type { FlagOverrides } from "./FlagOverrides";
-import type { ClientReadyState, IProvidesHooks } from "./Hooks";
+import type { IProvidesHooks } from "./Hooks";
 import { Hooks } from "./Hooks";
 import { ProjectConfig } from "./ProjectConfig";
 import type { User } from "./RolloutEvaluator";
@@ -156,7 +157,7 @@ export abstract class OptionsBase {
 
   hooks: Hooks;
 
-  readyPromise: Promise<ClientReadyState>;
+  readyPromise: Promise<ClientCacheState>;
 
   constructor(apiKey: string, clientVersion: string, options?: IOptions | null,
     defaultCacheFactory?: ((options: OptionsBase) => IConfigCache) | null,

--- a/src/ConfigCatLogger.ts
+++ b/src/ConfigCatLogger.ts
@@ -20,7 +20,7 @@ export enum LogLevel {
 
 export type LogEventId = number;
 
-/** Represents a log message format with names arguments. */
+/** Represents a log message format with named arguments. */
 export class FormattableLogMessage {
   static from(...argNames: string[]): (strings: TemplateStringsArray, ...argValues: unknown[]) => FormattableLogMessage {
     return (strings: TemplateStringsArray, ...argValues: unknown[]) =>

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -1,7 +1,6 @@
 import type { OptionsBase } from "./ConfigCatClientOptions";
 import type { FetchErrorCauses, IConfigFetcher, IFetchResponse } from "./ConfigFetcher";
 import { FetchError, FetchResult, FetchStatus } from "./ConfigFetcher";
-import type { ClientReadyState } from "./Hooks";
 import { Config, ProjectConfig, RedirectMode } from "./ProjectConfig";
 
 /** Contains the result of an `IConfigCatClient.forceRefresh` or `IConfigCatClient.forceRefreshAsync` operation. */
@@ -34,6 +33,14 @@ export class RefreshResult {
   }
 }
 
+/** Specifies the possible states of the local cache. */
+export enum ClientCacheState {
+  NoFlagData,
+  HasLocalOverrideFlagDataOnly,
+  HasCachedFlagDataOnly,
+  HasUpToDateFlagData,
+}
+
 export interface IConfigService {
   getConfig(): Promise<ProjectConfig>;
 
@@ -45,7 +52,7 @@ export interface IConfigService {
 
   setOffline(): void;
 
-  getCacheState(cachedConfig: ProjectConfig): ClientReadyState;
+  getCacheState(cachedConfig: ProjectConfig): ClientCacheState;
 
   dispose(): void;
 }
@@ -285,7 +292,7 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     }
   }
 
-  abstract getCacheState(cachedConfig: ProjectConfig): ClientReadyState;
+  abstract getCacheState(cachedConfig: ProjectConfig): ClientCacheState;
 
   protected onCacheSynced(cachedConfig: ProjectConfig): void {
     this.options.hooks.emit("clientReady", this.getCacheState(cachedConfig));

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -45,6 +45,8 @@ export interface IConfigService {
 
   setOffline(): void;
 
+  getCacheState(cachedConfig: ProjectConfig): ClientReadyState;
+
   dispose(): void;
 }
 
@@ -283,10 +285,15 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
     }
   }
 
-  protected abstract getReadyState(cachedConfig: ProjectConfig): ClientReadyState;
+  abstract getCacheState(cachedConfig: ProjectConfig): ClientReadyState;
 
-  protected async syncUpWithCache(): Promise<void> {
+  protected onCacheSynced(cachedConfig: ProjectConfig): void {
+    this.options.hooks.emit("clientReady", this.getCacheState(cachedConfig));
+  }
+
+  protected async syncUpWithCache(): Promise<ProjectConfig> {
     const cachedConfig = await this.options.cache.get(this.cacheKey);
-    this.options.hooks.emit("clientReady", this.getReadyState(cachedConfig));
+    this.onCacheSynced(cachedConfig);
+    return cachedConfig;
   }
 }

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -19,7 +19,7 @@ export const ClientReadyState = ClientCacheState;
 /** Hooks (events) that can be emitted by `ConfigCatClient`. */
 export type HookEvents = {
   /** Occurs when the client is ready to provide the actual value of feature flags or settings. */
-  clientReady: [state: ClientCacheState];
+  clientReady: [cacheState: ClientCacheState];
   /** Occurs after the value of a feature flag of setting has been evaluated. */
   flagEvaluated: [evaluationDetails: IEvaluationDetails];
   /** Occurs after the locally cached config has been updated. */

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -1,20 +1,25 @@
+import { ClientCacheState } from "./ConfigServiceBase";
 import type { IEventEmitter, IEventProvider } from "./EventEmitter";
 import { NullEventEmitter } from "./EventEmitter";
 import type { IConfig } from "./ProjectConfig";
 import type { IEvaluationDetails } from "./RolloutEvaluator";
 
-/** Contains the initialization state of `ConfigCatClient`. */
-export enum ClientReadyState {
-  NoFlagData,
-  HasLocalOverrideFlagDataOnly,
-  HasCachedFlagDataOnly,
-  HasUpToDateFlagData,
-}
+/**
+ * Contains the initialization state of `ConfigCatClient`.
+ * @deprecated This type is obsolete and will be removed from the public API in a future major version. Please use `ClientCacheState` instead.
+ */
+export type ClientReadyState = ClientCacheState;
+
+/**
+ * @deprecated This type is obsolete and will be removed from the public API in a future major version. Please use `ClientCacheState` instead.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const ClientReadyState = ClientCacheState;
 
 /** Hooks (events) that can be emitted by `ConfigCatClient`. */
 export type HookEvents = {
   /** Occurs when the client is ready to provide the actual value of feature flags or settings. */
-  clientReady: [state: ClientReadyState];
+  clientReady: [state: ClientCacheState];
   /** Occurs after the value of a feature flag of setting has been evaluated. */
   flagEvaluated: [evaluationDetails: IEvaluationDetails];
   /** Occurs after the locally cached config has been updated. */

--- a/src/LazyLoadConfigService.ts
+++ b/src/LazyLoadConfigService.ts
@@ -2,8 +2,7 @@ import type { LazyLoadOptions } from "./ConfigCatClientOptions";
 import type { LoggerWrapper } from "./ConfigCatLogger";
 import type { IConfigFetcher } from "./ConfigFetcher";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
-import { ConfigServiceBase } from "./ConfigServiceBase";
-import { ClientReadyState } from "./Hooks";
+import { ClientCacheState, ConfigServiceBase } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
 
 export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> implements IConfigService {
@@ -47,15 +46,15 @@ export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> im
     return super.refreshConfigAsync();
   }
 
-  getCacheState(cachedConfig: ProjectConfig): ClientReadyState {
+  getCacheState(cachedConfig: ProjectConfig): ClientCacheState {
     if (cachedConfig.isEmpty) {
-      return ClientReadyState.NoFlagData;
+      return ClientCacheState.NoFlagData;
     }
 
     if (cachedConfig.isExpired(this.cacheTimeToLiveMs)) {
-      return ClientReadyState.HasCachedFlagDataOnly;
+      return ClientCacheState.HasCachedFlagDataOnly;
     }
 
-    return ClientReadyState.HasUpToDateFlagData;
+    return ClientCacheState.HasUpToDateFlagData;
   }
 }

--- a/src/LazyLoadConfigService.ts
+++ b/src/LazyLoadConfigService.ts
@@ -47,7 +47,7 @@ export class LazyLoadConfigService extends ConfigServiceBase<LazyLoadOptions> im
     return super.refreshConfigAsync();
   }
 
-  protected getReadyState(cachedConfig: ProjectConfig): ClientReadyState {
+  getCacheState(cachedConfig: ProjectConfig): ClientReadyState {
     if (cachedConfig.isEmpty) {
       return ClientReadyState.NoFlagData;
     }

--- a/src/ManualPollConfigService.ts
+++ b/src/ManualPollConfigService.ts
@@ -14,7 +14,7 @@ export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions
     super.syncUpWithCache();
   }
 
-  protected getReadyState(cachedConfig: ProjectConfig): ClientReadyState {
+  getCacheState(cachedConfig: ProjectConfig): ClientReadyState {
     if (cachedConfig.isEmpty) {
       return ClientReadyState.NoFlagData;
     }

--- a/src/ManualPollConfigService.ts
+++ b/src/ManualPollConfigService.ts
@@ -1,8 +1,7 @@
 import type { ManualPollOptions } from "./ConfigCatClientOptions";
 import type { IConfigFetcher } from "./ConfigFetcher";
 import type { IConfigService, RefreshResult } from "./ConfigServiceBase";
-import { ConfigServiceBase } from "./ConfigServiceBase";
-import { ClientReadyState } from "./Hooks";
+import { ClientCacheState, ConfigServiceBase } from "./ConfigServiceBase";
 import type { ProjectConfig } from "./ProjectConfig";
 
 export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions> implements IConfigService {
@@ -14,12 +13,12 @@ export class ManualPollConfigService extends ConfigServiceBase<ManualPollOptions
     super.syncUpWithCache();
   }
 
-  getCacheState(cachedConfig: ProjectConfig): ClientReadyState {
+  getCacheState(cachedConfig: ProjectConfig): ClientCacheState {
     if (cachedConfig.isEmpty) {
-      return ClientReadyState.NoFlagData;
+      return ClientCacheState.NoFlagData;
     }
 
-    return ClientReadyState.HasCachedFlagDataOnly;
+    return ClientCacheState.HasCachedFlagDataOnly;
   }
 
   async getConfig(): Promise<ProjectConfig> {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -10,3 +10,8 @@ export function errorToString(err: any, includeStackTrace = false): string {
     ? includeStackTrace && err.stack ? err.stack : err.toString()
     : err + "";
 }
+
+export function isPromiseLike<T>(obj: unknown): obj is PromiseLike<T> {
+  // See also: https://stackoverflow.com/a/27746324/8656352
+  return typeof (obj as PromiseLike<T>)?.then === "function";
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,7 +1,9 @@
-export function delay(delayMs: number, obtainCancel?: (cancel: () => void) => void): Promise<void> {
+export function delay(delayMs: number, delayCleanup?: { clearTimer?: () => void } | null): Promise<void> {
   let timerId: ReturnType<typeof setTimeout>;
   const promise = new Promise<void>(resolve => timerId = setTimeout(resolve, delayMs));
-  obtainCancel?.(() => clearTimeout(timerId));
+  if (delayCleanup) {
+    delayCleanup.clearTimer = () => clearTimeout(timerId);
+  }
   return promise;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ export { User } from "./RolloutEvaluator";
 
 export { OverrideBehaviour } from "./FlagOverrides";
 
-export { RefreshResult } from "./ConfigServiceBase";
+export { ClientCacheState, RefreshResult } from "./ConfigServiceBase";
 
 export type { IProvidesHooks, HookEvents } from "./Hooks";
 

--- a/test/ConfigCatClientOptionsTests.ts
+++ b/test/ConfigCatClientOptionsTests.ts
@@ -1,9 +1,10 @@
 import { assert, expect } from "chai";
 import "mocha";
-import { ExternalConfigCache, IConfigCache, IConfigCatCache, InMemoryConfigCache } from "../src/ConfigCatCache";
+import { ExternalConfigCache, IConfigCache, InMemoryConfigCache } from "../src/ConfigCatCache";
 import { AutoPollOptions, LazyLoadOptions, ManualPollOptions, OptionsBase } from "../src/ConfigCatClientOptions";
 import { ConfigCatConsoleLogger, IConfigCatLogger, LogEventId, LogLevel, LogMessage, LoggerWrapper } from "../src/ConfigCatLogger";
 import { ProjectConfig } from "../src/ProjectConfig";
+import { FakeExternalCache } from "./helpers/fakes";
 
 describe("Options", () => {
 
@@ -409,15 +410,6 @@ class FakeCache implements IConfigCache {
     throw new Error("Method not implemented.");
   }
   getInMemory(): ProjectConfig {
-    throw new Error("Method not implemented.");
-  }
-}
-
-class FakeExternalCache implements IConfigCatCache {
-  set(key: string, value: string): void | Promise<void> {
-    throw new Error("Method not implemented.");
-  }
-  get(key: string): string | Promise<string | null | undefined> | null | undefined {
     throw new Error("Method not implemented.");
   }
 }

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -6,7 +6,7 @@ import { ConfigCatClient, IConfigCatClient, IConfigCatKernel } from "../src/Conf
 import { AutoPollOptions, IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions, IOptions, LazyLoadOptions, ManualPollOptions, OptionsBase, PollingMode } from "../src/ConfigCatClientOptions";
 import { LogLevel } from "../src/ConfigCatLogger";
 import { IFetchResponse } from "../src/ConfigFetcher";
-import { ConfigServiceBase, IConfigService, RefreshResult } from "../src/ConfigServiceBase";
+import { ClientCacheState, ConfigServiceBase, IConfigService, RefreshResult } from "../src/ConfigServiceBase";
 import { MapOverrideDataSource, OverrideBehaviour } from "../src/FlagOverrides";
 import { ClientReadyState, IProvidesHooks } from "../src/Hooks";
 import { LazyLoadConfigService } from "../src/LazyLoadConfigService";
@@ -1313,18 +1313,18 @@ describe("ConfigCatClient", () => {
   });
 
   for (const pollingMode of [PollingMode.AutoPoll, PollingMode.LazyLoad, PollingMode.ManualPoll]) {
-    const testCases: [boolean, boolean, string, ClientReadyState, ClientReadyState][] = [
-      [false, false, "empty", ClientReadyState.NoFlagData, ClientReadyState.NoFlagData],
-      [true, false, "empty", ClientReadyState.NoFlagData, ClientReadyState.NoFlagData],
-      [true, true, "empty", ClientReadyState.NoFlagData, ClientReadyState.NoFlagData],
-      [true, false, "expired", ClientReadyState.HasCachedFlagDataOnly, ClientReadyState.HasCachedFlagDataOnly],
-      [true, true, "expired", ClientReadyState.NoFlagData, ClientReadyState.HasCachedFlagDataOnly],
+    const testCases: [boolean, boolean, string, ClientCacheState, ClientCacheState][] = [
+      [false, false, "empty", ClientCacheState.NoFlagData, ClientCacheState.NoFlagData],
+      [true, false, "empty", ClientCacheState.NoFlagData, ClientCacheState.NoFlagData],
+      [true, true, "empty", ClientCacheState.NoFlagData, ClientCacheState.NoFlagData],
+      [true, false, "expired", ClientCacheState.HasCachedFlagDataOnly, ClientCacheState.HasCachedFlagDataOnly],
+      [true, true, "expired", ClientCacheState.NoFlagData, ClientCacheState.HasCachedFlagDataOnly],
     ];
 
     if (pollingMode !== PollingMode.ManualPoll) {
       testCases.push(
-        [true, false, "fresh", ClientReadyState.HasUpToDateFlagData, ClientReadyState.HasUpToDateFlagData],
-        [true, true, "fresh", ClientReadyState.NoFlagData, ClientReadyState.HasUpToDateFlagData],
+        [true, false, "fresh", ClientCacheState.HasUpToDateFlagData, ClientCacheState.HasUpToDateFlagData],
+        [true, true, "fresh", ClientCacheState.NoFlagData, ClientCacheState.HasUpToDateFlagData],
       );
     }
 

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -3,7 +3,7 @@ import "mocha";
 import { AutoPollConfigService } from "../src/AutoPollConfigService";
 import { IConfigCache } from "../src/ConfigCatCache";
 import { ConfigCatClient, IConfigCatClient, IConfigCatKernel } from "../src/ConfigCatClient";
-import { AutoPollOptions, IAutoPollOptions, IManualPollOptions, LazyLoadOptions, ManualPollOptions, OptionsBase, PollingMode } from "../src/ConfigCatClientOptions";
+import { AutoPollOptions, IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions, IOptions, LazyLoadOptions, ManualPollOptions, OptionsBase, PollingMode } from "../src/ConfigCatClientOptions";
 import { LogLevel } from "../src/ConfigCatLogger";
 import { IFetchResponse } from "../src/ConfigFetcher";
 import { ConfigServiceBase, IConfigService, RefreshResult } from "../src/ConfigServiceBase";
@@ -15,7 +15,7 @@ import { Config, IConfig, ProjectConfig, Setting } from "../src/ProjectConfig";
 import { IEvaluateResult, IEvaluationDetails, IRolloutEvaluator, User } from "../src/RolloutEvaluator";
 import { delay } from "../src/Utils";
 import "./helpers/ConfigCatClientCacheExtensions";
-import { FakeCache, FakeConfigCatKernel, FakeConfigFetcher, FakeConfigFetcherBase, FakeConfigFetcherWithAlwaysVariableEtag, FakeConfigFetcherWithNullNewConfig, FakeConfigFetcherWithPercantageRules, FakeConfigFetcherWithRules, FakeConfigFetcherWithTwoCaseSensitiveKeys, FakeConfigFetcherWithTwoKeys, FakeConfigFetcherWithTwoKeysAndRules, FakeExternalCacheWithInitialData, FakeLogger } from "./helpers/fakes";
+import { FakeCache, FakeConfigCatKernel, FakeConfigFetcher, FakeConfigFetcherBase, FakeConfigFetcherWithAlwaysVariableEtag, FakeConfigFetcherWithNullNewConfig, FakeConfigFetcherWithPercantageRules, FakeConfigFetcherWithRules, FakeConfigFetcherWithTwoCaseSensitiveKeys, FakeConfigFetcherWithTwoKeys, FakeConfigFetcherWithTwoKeysAndRules, FakeExternalAsyncCache, FakeExternalCache, FakeExternalCacheWithInitialData, FakeLogger } from "./helpers/fakes";
 import { allowEventLoop } from "./helpers/utils";
 
 describe("ConfigCatClient", () => {
@@ -153,7 +153,7 @@ describe("ConfigCatClient", () => {
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, new Config(JSON.parse(configFetcherClass.configJson)), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, () => configCache);
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, {}, () => configCache);
     const client = new ConfigCatClient(options, configCatKernel);
 
     const user = new User("a@configcat.com");
@@ -194,7 +194,7 @@ describe("ConfigCatClient", () => {
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, new Config(JSON.parse(configFetcherClass.configJson)), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, () => configCache);
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, {}, () => configCache);
     const client = new ConfigCatClient(options, configCatKernel);
 
     const user = new User("a@configcat.com");
@@ -235,7 +235,7 @@ describe("ConfigCatClient", () => {
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, new Config(JSON.parse(configFetcherClass.configJson)), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, () => configCache);
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, {}, () => configCache);
     const client = new ConfigCatClient(options, configCatKernel);
 
     const user = new User("a@configcat.com");
@@ -279,7 +279,7 @@ describe("ConfigCatClient", () => {
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, new Config(JSON.parse(configFetcherClass.configJson)), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, () => configCache);
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, {}, () => configCache);
     const client = new ConfigCatClient(options, configCatKernel);
 
     const user = new User("a@configcat.com");
@@ -322,7 +322,7 @@ describe("ConfigCatClient", () => {
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, new Config(JSON.parse(configFetcherClass.configJson)), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, () => configCache);
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, {}, () => configCache);
     const client = new ConfigCatClient(options, configCatKernel);
 
     const err = new Error("Something went wrong.");
@@ -375,7 +375,7 @@ describe("ConfigCatClient", () => {
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, new Config(JSON.parse(configFetcherClass.configJson)), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, () => configCache);
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, {}, () => configCache);
     const client = new ConfigCatClient(options, configCatKernel);
 
     const user = new User("a@configcat.com");
@@ -425,7 +425,7 @@ describe("ConfigCatClient", () => {
     const cachedPc = new ProjectConfig(configFetcherClass.configJson, new Config(JSON.parse(configFetcherClass.configJson)), timestamp, "etag");
     const configCache = new FakeCache(cachedPc);
     const configCatKernel: FakeConfigCatKernel = { configFetcher: new configFetcherClass(), sdkType: "common", sdkVersion: "1.0.0" };
-    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, () => configCache);
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, {}, () => configCache);
     const client = new ConfigCatClient(options, configCatKernel);
 
     const err = new Error("Something went wrong.");
@@ -1197,7 +1197,7 @@ describe("ConfigCatClient", () => {
       const configCache = new FakeCache();
       const configCatKernel: FakeConfigCatKernel = { configFetcher, sdkType: "common", sdkVersion: "1.0.0", defaultCacheFactory: () => configCache };
       const userOptions: IManualPollOptions = addListenersViaOptions ? { setupHooks } : {};
-      const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, userOptions, configCatKernel.defaultCacheFactory);
+      const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, userOptions, configCatKernel.defaultCacheFactory);
 
       const expectedErrorMessage = "Error occurred in the `forceRefreshAsync` method.";
       const expectedErrorException = new Error("Something went wrong.");
@@ -1273,7 +1273,7 @@ describe("ConfigCatClient", () => {
     const configFetcher = new FakeConfigFetcherBase(null, 100, (lastConfig, lastETag) => { throw errorException; });
     const configCache = new FakeCache();
     const configCatKernel: FakeConfigCatKernel = { configFetcher, sdkType: "common", sdkVersion: "1.0.0", defaultCacheFactory: () => configCache };
-    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCatKernel.defaultCacheFactory);
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, {}, configCatKernel.defaultCacheFactory);
 
     const client = new ConfigCatClient(options, configCatKernel);
 
@@ -1291,7 +1291,7 @@ describe("ConfigCatClient", () => {
     const configFetcher = new FakeConfigFetcherBase(null, 100, (lastConfig, lastETag) => { throw errorException; });
     const configCache = new FakeCache();
     const configCatKernel: FakeConfigCatKernel = { configFetcher, sdkType: "common", sdkVersion: "1.0.0", defaultCacheFactory: () => configCache };
-    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkType, {}, configCatKernel.defaultCacheFactory);
+    const options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, {}, configCatKernel.defaultCacheFactory);
 
     const client = new ConfigCatClient(options, configCatKernel);
 
@@ -1311,4 +1311,70 @@ describe("ConfigCatClient", () => {
     expect(refreshResult.errorMessage).to.include(errorMessage);
     assert.strictEqual(refreshResult.errorException, errorException);
   });
+
+  for (const pollingMode of [PollingMode.AutoPoll, PollingMode.LazyLoad, PollingMode.ManualPoll]) {
+    const testCases: [boolean, boolean, string, ClientReadyState, ClientReadyState][] = [
+      [false, false, "empty", ClientReadyState.NoFlagData, ClientReadyState.NoFlagData],
+      [true, false, "empty", ClientReadyState.NoFlagData, ClientReadyState.NoFlagData],
+      [true, true, "empty", ClientReadyState.NoFlagData, ClientReadyState.NoFlagData],
+      [true, false, "expired", ClientReadyState.HasCachedFlagDataOnly, ClientReadyState.HasCachedFlagDataOnly],
+      [true, true, "expired", ClientReadyState.NoFlagData, ClientReadyState.HasCachedFlagDataOnly],
+    ];
+
+    if (pollingMode !== PollingMode.ManualPoll) {
+      testCases.push(
+        [true, false, "fresh", ClientReadyState.HasUpToDateFlagData, ClientReadyState.HasUpToDateFlagData],
+        [true, true, "fresh", ClientReadyState.NoFlagData, ClientReadyState.HasUpToDateFlagData],
+      );
+    }
+
+    for (const [externalCache, asyncCacheGet, initialCacheState, expectedImmediateCacheState, expectedDelayedCacheState] of testCases) {
+      const cacheType = externalCache ? (asyncCacheGet ? "external cache (async get)" : "external cache (sync get)") : "in-memory cache";
+      it(`${PollingMode[pollingMode]} - snapshot() should correctly report client cache state - ${cacheType} - ${initialCacheState}`, async () => {
+        const configFetcher = new FakeConfigFetcher(100);
+        const configJson = configFetcher.constructor.configJson;
+        const configCatKernel: FakeConfigCatKernel = { configFetcher, sdkType: "common", sdkVersion: "1.0.0" };
+        const asyncCacheDelayMs = 1, expirationSeconds = 5;
+
+        const clientOptions: IOptions = {
+          cache: externalCache ? (asyncCacheGet ? new FakeExternalAsyncCache(asyncCacheDelayMs) : new FakeExternalCache()) : null
+        };
+        let options: OptionsBase;
+        switch (pollingMode) {
+          case PollingMode.AutoPoll:
+            (clientOptions as IAutoPollOptions).pollIntervalSeconds = expirationSeconds;
+            options = new AutoPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, clientOptions, configCatKernel.defaultCacheFactory);
+            break;
+          case PollingMode.LazyLoad:
+            (clientOptions as ILazyLoadingOptions).cacheTimeToLiveSeconds = expirationSeconds;
+            options = new LazyLoadOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, clientOptions, configCatKernel.defaultCacheFactory);
+            break;
+          case PollingMode.ManualPoll:
+            options = new ManualPollOptions("APIKEY", configCatKernel.sdkType, configCatKernel.sdkVersion, clientOptions, configCatKernel.defaultCacheFactory);
+            break;
+        }
+
+        if (clientOptions.cache && (initialCacheState === "expired" || initialCacheState === "fresh")) {
+          const timestamp = ProjectConfig.generateTimestamp() - expirationSeconds * 1000 * (initialCacheState === "expired" ? 1.5 : 0.5);
+          const pc = new ProjectConfig(configJson, new Config(configJson), timestamp, "\"etag\"");
+          await clientOptions.cache.set(options.getCacheKey(), ProjectConfig.serialize(pc));
+        }
+
+        const client = new ConfigCatClient(options, configCatKernel);
+        try {
+          // After client instantiation, if IConfigCatCache.get is a sync operation, the snapshot should immediately report the expected cache state.
+          let snapshot = client.snapshot();
+          assert.equal(expectedImmediateCacheState, snapshot.clientCacheState);
+
+          // Otherwise, it should report the expected cache state after some delay.
+          await delay(asyncCacheDelayMs + 10);
+          snapshot = client.snapshot();
+          assert.equal(expectedDelayedCacheState, snapshot.clientCacheState);
+        }
+        finally {
+          client.dispose();
+        }
+      });
+    }
+  }
 });

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -1225,6 +1225,7 @@ describe("ConfigCatClient", () => {
         get isOffline(): boolean { return false; }
         setOnline(): void { }
         setOffline(): void { }
+        getCacheState(): ClientReadyState { return ClientReadyState.NoFlagData; }
         dispose(): void { }
       };
 
@@ -1300,6 +1301,7 @@ describe("ConfigCatClient", () => {
       get isOffline(): boolean { return false; }
       setOnline(): void { }
       setOffline(): void { }
+      getCacheState(): ClientReadyState { return ClientReadyState.NoFlagData; }
       dispose(): void { }
     };
 

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -1364,12 +1364,12 @@ describe("ConfigCatClient", () => {
         try {
           // After client instantiation, if IConfigCatCache.get is a sync operation, the snapshot should immediately report the expected cache state.
           let snapshot = client.snapshot();
-          assert.equal(expectedImmediateCacheState, snapshot.clientCacheState);
+          assert.equal(expectedImmediateCacheState, snapshot.cacheState);
 
           // Otherwise, it should report the expected cache state after some delay.
           await delay(asyncCacheDelayMs + 10);
           snapshot = client.snapshot();
-          assert.equal(expectedDelayedCacheState, snapshot.clientCacheState);
+          assert.equal(expectedDelayedCacheState, snapshot.cacheState);
         }
         finally {
           client.dispose();

--- a/test/DataGovernanceTests.ts
+++ b/test/DataGovernanceTests.ts
@@ -304,7 +304,7 @@ export class FakeConfigServiceBase extends ConfigServiceBase<FakeOptions> {
     return baseUrl + "/configuration-files/API_KEY/config_v5.json?sdk=" + this.options.clientVersion;
   }
 
-  protected getReadyState(cachedConfig: ProjectConfig): ClientReadyState {
+  getCacheState(cachedConfig: ProjectConfig): ClientReadyState {
     throw new Error("Method not implemented.");
   }
 }

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -48,6 +48,35 @@ export class FakeCache implements IConfigCache {
   }
 }
 
+export class FakeExternalCache implements IConfigCatCache {
+  private cachedValue: string | undefined;
+
+  set(key: string, value: string): void {
+    this.cachedValue = value;
+  }
+
+  get(key: string): string | undefined {
+    return this.cachedValue;
+  }
+}
+
+export class FakeExternalAsyncCache implements IConfigCatCache {
+  private cachedValue: string | undefined;
+
+  constructor(private readonly delayMs = 0) {
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    await delay(this.delayMs);
+    this.cachedValue = value;
+  }
+
+  async get(key: string): Promise<string | undefined> {
+    await delay(this.delayMs);
+    return this.cachedValue;
+  }
+}
+
 export class FakeExternalCacheWithInitialData implements IConfigCatCache {
   expirationDelta: number;
 


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR proposes an addition to the snapshot API:

```ts
export interface IConfigCatClientSnapshot {
  readonly clientCacheState: ClientReadyState;
}
```

This way users could get information about the "up-to-dateness" of the captured state actively instead of subscribing to the `clientReady` hook and waiting for that event. This could be especially useful in frontend apps where the rendering of the UI may happen before `clientReady` fires.

Via the proposed API, the user could query the config cache state right away after instantiating the ConfigCat client *when* the cache implementation being used is synchronous. (And currently all the cache implementations we provide out-of-the-box - in-memory, local storage - are synchronous). In the case of an up-to-date snapshot, the UI could be initialized before rendering without waiting for the `clientReady` event or making a `getValueAsync` call, etc. This could prevent some flickering when a loader is displayed until the feature flag value becomes available.

Apart from this, the PR also includes a few minor fixes and improvements, mostly around `AutoPollConfigService`.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
