### PR TITLE
Correct clientReady hook in Auto Poll mode

### DIFF
--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -28,7 +28,7 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
 
       // This promise will be resolved when
       // 1. the cache contains a valid config at startup (see startRefreshWorker) or
-      // 2. config.json is downloaded the first time (see onConfigUpdated) or
+      // 2. config json is fetched the first time, regardless of success or failure (see onConfigUpdated) or
       // 3. maxInitWaitTimeSeconds > 0 and maxInitWaitTimeSeconds has passed (see the setTimeout call below).
       this.initialization = new Promise(resolve => this.signalInitialization = () => {
         this.initialized = true;
@@ -117,8 +117,8 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
     }
   }
 
-  protected onConfigUpdated(newConfig: ProjectConfig): void {
-    super.onConfigUpdated(newConfig);
+  protected onConfigFetched(newConfig: ProjectConfig): void {
+    super.onConfigFetched(newConfig);
     this.signalInitialization();
   }
 

--- a/src/ConfigServiceBase.ts
+++ b/src/ConfigServiceBase.ts
@@ -296,13 +296,11 @@ export abstract class ConfigServiceBase<TOptions extends OptionsBase> {
 
   abstract getCacheState(cachedConfig: ProjectConfig): ClientCacheState;
 
-  protected onCacheSynced(cachedConfig: ProjectConfig): void {
-    this.options.hooks.emit("clientReady", this.getCacheState(cachedConfig));
-  }
-
-  protected async syncUpWithCache(): Promise<ProjectConfig> {
+  protected async syncUpWithCache(suppressEmitClientReady = false): Promise<ProjectConfig> {
     const cachedConfig = await this.options.cache.get(this.cacheKey);
-    this.onCacheSynced(cachedConfig);
+    if (!suppressEmitClientReady) {
+      this.options.hooks.emit("clientReady", this.getCacheState(cachedConfig));
+    }
     return cachedConfig;
   }
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

So far the `clientReady` event has fired in Auto Poll mode only when receiving 200, 304, 403 or 404 status code. In other cases (including the case of network errors) `maxInitWaitTime` has been waited before firing `clientReady`.

Breaking changes:
* Change the behavior of the `clientReady` hook to fire after the completion of the first fetch operation in Auto Poll mode - regardless of success or failure - to make the behavior consistent with other SDKs.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
