### PR TITLE
Fix issue with User custom property initialization

### DIFF
--- a/src/User.ts
+++ b/src/User.ts
@@ -46,7 +46,7 @@ export class User {
      * * accept `string` values containing a valid JSON string which can be deserialized to an array of `string`,
      * * all other values are considered invalid (a warning will be logged and the currently evaluated targeting rule will be skipped).
      **/
-    public custom: { [key: string]: UserAttributeValue } = {}
+    public custom?: { [key: string]: UserAttributeValue },
   ) {
   }
 }

--- a/test/EvaluationLogTests.ts
+++ b/test/EvaluationLogTests.ts
@@ -89,6 +89,10 @@ function createUser(userRaw?: Readonly<{ [key: string]: string }>): User | undef
     user.country = country;
   }
 
+  if (!user.custom) {
+    user.custom = {};
+  }
+
   const wellKnownAttributes: string[] = [identifierAttribute, emailAttribute, countryAttribute];
   for (const attributeName of Object.keys(userRaw)) {
     if (wellKnownAttributes.indexOf(attributeName) < 0) {

--- a/test/MatrixTests.ts
+++ b/test/MatrixTests.ts
@@ -128,6 +128,8 @@ function createUser(columns: ReadonlyArray<string>, headers: string[]): User | u
     result.country = country;
   }
 
+  result.custom = {};
+
   if (custom && custom !== USERNULL) {
     result.custom[headers[3]] = custom;
   }

--- a/test/UserTests.ts
+++ b/test/UserTests.ts
@@ -9,6 +9,8 @@ const countryAttribute: WellKnownUserObjectAttribute = "Country";
 
 function createUser(attributeName: string, attributeValue: string) {
   const user = new User("");
+  user.custom = {};
+
   switch (attributeName) {
     case identifierAttribute:
       user.identifier = attributeValue;


### PR DESCRIPTION
Documentation says that in User Object the **custom** is **Optional** dictionary of strings.
However, an error occurs on my end when I invoke the getClient function.

Documentation reference: https://configcat.com/docs/sdk-reference/js-ssr/#user-object

Please check attached screenshot with error
<img width="1218" alt="Screenshot 2023-11-26 at 3 28 06 PM" src="https://github.com/configcat/common-js/assets/11815472/92dc3d29-404c-4c5d-a090-a0764229161f">