### PR TITLE
Add option for detecting changes to flag overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-common",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-common",
-      "version": "9.1.0",
+      "version": "9.2.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-common",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "ConfigCat is a configuration as a service that lets you manage your features and configurations without actually deploying new code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/FlagOverrides.ts
+++ b/src/FlagOverrides.ts
@@ -39,8 +39,10 @@ export class MapOverrideDataSource implements IOverrideDataSource {
   private readonly initialSettings: { [name: string]: Setting };
   private readonly map?: { [name: string]: NonNullable<SettingValue> };
 
+  private readonly ["constructor"]!: typeof MapOverrideDataSource;
+
   constructor(map: { [name: string]: NonNullable<SettingValue> }, watchChanges?: boolean) {
-    this.initialSettings = (this.constructor as typeof MapOverrideDataSource).getCurrentSettings(map);
+    this.initialSettings = this.constructor.getCurrentSettings(map);
     if (watchChanges) {
       this.map = map;
     }
@@ -52,7 +54,7 @@ export class MapOverrideDataSource implements IOverrideDataSource {
 
   getOverridesSync(): { [name: string]: Setting } {
     return this.map
-      ? (this.constructor as typeof MapOverrideDataSource).getCurrentSettings(this.map)
+      ? this.constructor.getCurrentSettings(this.map)
       : this.initialSettings;
   }
 }

--- a/src/FlagOverrides.ts
+++ b/src/FlagOverrides.ts
@@ -31,20 +31,29 @@ export interface IOverrideDataSource {
 }
 
 export class MapOverrideDataSource implements IOverrideDataSource {
-  private readonly map: { [name: string]: Setting } = {};
+  private static getCurrentSettings(map: { [name: string]: NonNullable<SettingValue> }) {
+    return Object.fromEntries(Object.entries(map)
+      .map(([key, value]) => [key, Setting.fromValue(value)]));
+  }
 
-  constructor(map: { [name: string]: NonNullable<SettingValue> }) {
-    this.map = Object.fromEntries(Object.entries(map).map(([key, value]) => {
-      return [key, Setting.fromValue(value)];
-    }));
+  private readonly initialSettings: { [name: string]: Setting };
+  private readonly map?: { [name: string]: NonNullable<SettingValue> };
+
+  constructor(map: { [name: string]: NonNullable<SettingValue> }, watchChanges?: boolean) {
+    this.initialSettings = (this.constructor as typeof MapOverrideDataSource).getCurrentSettings(map);
+    if (watchChanges) {
+      this.map = map;
+    }
   }
 
   getOverrides(): Promise<{ [name: string]: Setting }> {
-    return Promise.resolve(this.map);
+    return Promise.resolve(this.getOverridesSync());
   }
 
   getOverridesSync(): { [name: string]: Setting } {
-    return this.map;
+    return this.map
+      ? (this.constructor as typeof MapOverrideDataSource).getCurrentSettings(this.map)
+      : this.initialSettings;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,9 @@ import type { IAutoPollOptions, ILazyLoadingOptions, IManualPollOptions, Options
 import { PollingMode } from "./ConfigCatClientOptions";
 import type { IConfigCatLogger } from "./ConfigCatLogger";
 import { ConfigCatConsoleLogger, LogLevel } from "./ConfigCatLogger";
+import { FlagOverrides, MapOverrideDataSource, OverrideBehaviour } from "./FlagOverrides";
 import { setupPolyfills } from "./Polyfills";
+import type { SettingValue } from "./ProjectConfig";
 
 setupPolyfills();
 
@@ -37,6 +39,19 @@ export function createConsoleLogger(logLevel: LogLevel): IConfigCatLogger {
   return new ConfigCatConsoleLogger(logLevel);
 }
 
+/**
+ * Creates an instance of `FlagOverrides` that uses a map data source.
+ * @param map The map that contains the overrides.
+ * @param behaviour The override behaviour.
+ * Specifies whether the local values should override the remote values
+ * or local values should only be used when a remote value doesn't exist
+ * or the local values should be used only.
+ * @param watchChanges If set to `true`, the input map will be tracked for changes.
+ */
+export function createFlagOverridesFromMap(map: { [name: string]: NonNullable<SettingValue> }, behaviour: OverrideBehaviour, watchChanges?: boolean): FlagOverrides {
+  return new FlagOverrides(new MapOverrideDataSource(map, watchChanges), behaviour);
+}
+
 /* Public types for platform-specific SDKs */
 
 // List types here which are required to implement the platform-specific SDKs but shouldn't be exposed to end users.
@@ -51,13 +66,9 @@ export type { OptionsBase } from "./ConfigCatClientOptions";
 
 export type { IConfigCache } from "./ConfigCatCache";
 
-export { ExternalConfigCache } from "./ConfigCatCache";
+export { InMemoryConfigCache, ExternalConfigCache } from "./ConfigCatCache";
 
 export type { IEventProvider, IEventEmitter } from "./EventEmitter";
-
-export type { IOverrideDataSource } from "./FlagOverrides";
-
-export { FlagOverrides, MapOverrideDataSource } from "./FlagOverrides";
 
 /* Public types for end users */
 
@@ -101,7 +112,9 @@ export type { UserAttributeValue } from "./User";
 
 export { User } from "./User";
 
-export { OverrideBehaviour } from "./FlagOverrides";
+export type { FlagOverrides };
+
+export { OverrideBehaviour };
 
 export { ClientCacheState, RefreshResult } from "./ConfigServiceBase";
 

--- a/test/ConfigV2EvaluationTests.ts
+++ b/test/ConfigV2EvaluationTests.ts
@@ -1,7 +1,8 @@
 import { assert } from "chai";
 import "mocha";
-import { FlagOverrides, IManualPollOptions, MapOverrideDataSource, OverrideBehaviour, SettingValue, User, UserAttributeValue } from "../src";
+import { IManualPollOptions, OverrideBehaviour, SettingValue, User, UserAttributeValue } from "../src";
 import { LogLevel, LoggerWrapper } from "../src/ConfigCatLogger";
+import { FlagOverrides, MapOverrideDataSource } from "../src/FlagOverrides";
 import { RolloutEvaluator, evaluate, isAllowedValue } from "../src/RolloutEvaluator";
 import { errorToString } from "../src/Utils";
 import { CdnConfigLocation, LocalFileConfigLocation } from "./helpers/ConfigLocation";

--- a/test/OverrideTests.ts
+++ b/test/OverrideTests.ts
@@ -15,25 +15,117 @@ describe("Local Overrides", () => {
       sdkType: "common",
       sdkVersion: "1.0.0"
     };
+
+    const overrideMap = {
+      enabledFeature: true,
+      disabledFeature: false,
+      intSetting: 5,
+      doubleSetting: 3.14,
+      stringSetting: "test"
+    };
+
     const options: AutoPollOptions = new AutoPollOptions("localhost", "common", "1.0.0", {
       flagOverrides: {
-        dataSource: new MapOverrideDataSource({
-          enabledFeature: true,
-          disabledFeature: false,
-          intSetting: 5,
-          doubleSetting: 3.14,
-          stringSetting: "test"
-        }),
+        dataSource: new MapOverrideDataSource(overrideMap),
         behaviour: OverrideBehaviour.LocalOnly
       }
     }, null);
     const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
 
-    assert.equal(await client.getValueAsync("enabledFeature", false), true);
-    assert.equal(await client.getValueAsync("disabledFeature", true), false);
-    assert.equal(await client.getValueAsync("intSetting", 0), 5);
-    assert.equal(await client.getValueAsync("doubleSetting", 0), 3.14);
-    assert.equal(await client.getValueAsync("stringSetting", ""), "test");
+    assert.equal(await client.getValueAsync("enabledFeature", null), true);
+    assert.equal(await client.getValueAsync("disabledFeature", null), false);
+    assert.equal(await client.getValueAsync("intSetting", null), 5);
+    assert.equal(await client.getValueAsync("doubleSetting", null), 3.14);
+    assert.equal(await client.getValueAsync("stringSetting", null), "test");
+
+    overrideMap.disabledFeature = true;
+    overrideMap.intSetting = -5;
+
+    assert.equal(await client.getValueAsync("enabledFeature", null), true);
+    assert.equal(await client.getValueAsync("disabledFeature", null), false);
+    assert.equal(await client.getValueAsync("intSetting", null), 5);
+    assert.equal(await client.getValueAsync("doubleSetting", null), 3.14);
+    assert.equal(await client.getValueAsync("stringSetting", null), "test");
+  });
+
+  it("Values from map - LocalOnly - watch changes - async", async () => {
+    const configCatKernel: FakeConfigCatKernel = {
+      configFetcher: new FakeConfigFetcherBase("{\"f\": { \"fakeKey\": { \"v\": false, \"p\": [], \"r\": [] } } }"),
+      sdkType: "common",
+      sdkVersion: "1.0.0"
+    };
+
+    const overrideMap = {
+      enabledFeature: true,
+      disabledFeature: false,
+      intSetting: 5,
+      doubleSetting: 3.14,
+      stringSetting: "test"
+    };
+
+    const options: AutoPollOptions = new AutoPollOptions("localhost", "common", "1.0.0", {
+      flagOverrides: {
+        dataSource: new MapOverrideDataSource(overrideMap, true),
+        behaviour: OverrideBehaviour.LocalOnly
+      }
+    }, null);
+    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
+
+    assert.equal(await client.getValueAsync("enabledFeature", null), true);
+    assert.equal(await client.getValueAsync("disabledFeature", null), false);
+    assert.equal(await client.getValueAsync("intSetting", null), 5);
+    assert.equal(await client.getValueAsync("doubleSetting", null), 3.14);
+    assert.equal(await client.getValueAsync("stringSetting", null), "test");
+
+    overrideMap.disabledFeature = true;
+    overrideMap.intSetting = -5;
+
+    assert.equal(await client.getValueAsync("enabledFeature", null), true);
+    assert.equal(await client.getValueAsync("disabledFeature", null), true);
+    assert.equal(await client.getValueAsync("intSetting", null), -5);
+    assert.equal(await client.getValueAsync("doubleSetting", null), 3.14);
+    assert.equal(await client.getValueAsync("stringSetting", null), "test");
+  });
+
+  it("Values from map - LocalOnly - watch changes - sync", async () => {
+    const configCatKernel: FakeConfigCatKernel = {
+      configFetcher: new FakeConfigFetcherBase("{\"f\": { \"fakeKey\": { \"v\": false, \"p\": [], \"r\": [] } } }"),
+      sdkType: "common",
+      sdkVersion: "1.0.0"
+    };
+
+    const overrideMap = {
+      enabledFeature: true,
+      disabledFeature: false,
+      intSetting: 5,
+      doubleSetting: 3.14,
+      stringSetting: "test"
+    };
+
+    const options: AutoPollOptions = new AutoPollOptions("localhost", "common", "1.0.0", {
+      flagOverrides: {
+        dataSource: new MapOverrideDataSource(overrideMap, true),
+        behaviour: OverrideBehaviour.LocalOnly
+      }
+    }, null);
+    const client: IConfigCatClient = new ConfigCatClient(options, configCatKernel);
+
+    let snapshot = client.snapshot();
+    assert.equal(await snapshot.getValue("enabledFeature", null), true);
+    assert.equal(await snapshot.getValue("disabledFeature", null), false);
+    assert.equal(await snapshot.getValue("intSetting", null), 5);
+    assert.equal(await snapshot.getValue("doubleSetting", null), 3.14);
+    assert.equal(await snapshot.getValue("stringSetting", null), "test");
+
+    overrideMap.disabledFeature = true;
+    overrideMap.intSetting = -5;
+
+    snapshot = client.snapshot();
+    assert.equal(await snapshot.getValue("enabledFeature", null), true);
+    assert.equal(await snapshot.getValue("disabledFeature", null), true);
+    assert.equal(await snapshot.getValue("intSetting", null), -5);
+    assert.equal(await snapshot.getValue("doubleSetting", null), 3.14);
+    assert.equal(await snapshot.getValue("stringSetting", null), "test");
   });
 
   it("Values from map - LocalOverRemote", async () => {


### PR DESCRIPTION
### Describe the purpose of your pull request

Moves the `createFlagOverridesFromMap` function to the `configcat-common` package and adds an optional parameter named `watchChanges` to the function which controls whether the client should detect changes to the flag override map after client initialization.

### Related issues (only if applicable)

https://trello.com/c/9jqzNyAI/381-konzisztencian%C3%B6vel%C5%91-improvementek

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
