### PR TITLE
Fix cache expiration-related issues in Auto Polling mode

### DIFF
--- a/.github/workflows/common-js-ci.yml
+++ b/.github/workflows/common-js-ci.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         node: [ 14, 16, 18, 20 ]
         os: [ macos-latest, ubuntu-latest, windows-latest ]
+        exclude:
+          - node: 14
+            os: macos-latest
       fail-fast: false
     name: Test [${{ matrix.os }}, Node ${{ matrix.node }}]
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-common",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-common",
-      "version": "9.3.0",
+      "version": "9.3.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3018,12 +3018,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -7269,12 +7269,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-common",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "ConfigCat is a configuration as a service that lets you manage your features and configurations without actually deploying new code.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/AutoPollConfigService.ts
+++ b/src/AutoPollConfigService.ts
@@ -164,11 +164,6 @@ export class AutoPollConfigService extends ConfigServiceBase<AutoPollOptions> im
   }
 
   private async refreshWorkerLogic(isFirstIteration: boolean, initialCacheSyncUp: ProjectConfig | Promise<ProjectConfig> | null) {
-    if (this.disposed) {
-      this.options.logger.debug("AutoPollConfigService.refreshWorkerLogic() - called on a disposed client.");
-      return;
-    }
-
     this.options.logger.debug("AutoPollConfigService.refreshWorkerLogic() - called.");
 
     const latestConfig = await (initialCacheSyncUp ?? this.options.cache.get(this.cacheKey));

--- a/src/ConfigCatLogger.ts
+++ b/src/ConfigCatLogger.ts
@@ -231,6 +231,14 @@ export class LoggerWrapper implements IConfigCatLogger {
     );
   }
 
+  autoPollConfigServiceErrorDuringPolling(ex: any): LogMessage {
+    return this.log(
+      LogLevel.Error, 1200,
+      "Error occurred during auto polling.",
+      ex
+    );
+  }
+
   /* SDK-specific error messages (2000-2999) */
 
   settingForVariationIdIsNotPresent(variationId: string): LogMessage {

--- a/test/ConfigCatClientTests.ts
+++ b/test/ConfigCatClientTests.ts
@@ -526,11 +526,13 @@ describe("ConfigCatClient", () => {
       setupHooks: hooks => hooks.on("configChanged", () => configChangedEventCount++)
     };
     const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", userOptions, null);
-    new ConfigCatClient(options, configCatKernel);
+    const client = new ConfigCatClient(options, configCatKernel);
+    try {
+      await delay(2.5 * pollIntervalSeconds * 1000);
 
-    await delay(2.5 * pollIntervalSeconds * 1000);
-
-    assert.equal(configChangedEventCount, 3);
+      assert.equal(configChangedEventCount, 3);
+    }
+    finally { client.dispose(); }
   });
 
   it("Initialization With AutoPollOptions - config doesn't change - should fire configChanged only once", async () => {
@@ -544,11 +546,13 @@ describe("ConfigCatClient", () => {
       setupHooks: hooks => hooks.on("configChanged", () => configChangedEventCount++)
     };
     const options: AutoPollOptions = new AutoPollOptions("APIKEY", "common", "1.0.0", userOptions, null);
-    new ConfigCatClient(options, configCatKernel);
+    const client = new ConfigCatClient(options, configCatKernel);
+    try {
+      await delay(2.5 * pollIntervalSeconds * 1000);
 
-    await delay(2.5 * pollIntervalSeconds * 1000);
-
-    assert.equal(configChangedEventCount, 1);
+      assert.equal(configChangedEventCount, 1); 
+    }
+    finally { client.dispose(); }
   });
 
   it("Initialization With AutoPollOptions - with maxInitWaitTimeSeconds - getValueAsync should wait", async () => {

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -185,8 +185,10 @@ export class FakeConfigFetcherWithAlwaysVariableEtag extends FakeConfigFetcher {
     return '{"f":{"debug":{"t":0,"v":{"b":true},"i":"abcdefgh"}}}';
   }
 
+  private eTag = 0;
+
   getEtag(): string {
-    return Math.random().toString();
+    return `"${(this.eTag++).toString(16).padStart(8, "0")}"`;
   }
 }
 


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR fixes multiple issues in Auto Polling mode:
* Cache expiration should be checked in every poll iteration, not just in the first one to reduce network traffic when the SDK uses a shared cache (e.g. browser application using local storage running in multiple tabs).
* Cache synchronization should happen even in offline mode in every poll iteration, not just in the first one to update in-memory cache when the SDK uses a shared cache.
* Poll iterations should be protected with try-catch so a potential exception doesn't stop the loop.

Together with these corrections, the polling loop has been made consistent with the one in .NET SDK, which makes the timing of the polling iterations more accurate.

### Related issues (only if applicable)

https://trello.com/c/gnqqRydc

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
