### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/common-js-ci.yml
+++ b/.github/workflows/common-js-ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Archive
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: checked-out-lib
           path: lib


### PR DESCRIPTION
### Describe the purpose of your pull request
Updates `actions/upload-artifact` to v4 because GitHub Actions refuse to run the CI workflow otherwise.

### Related issues (only if applicable)
n/a

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
