### PR TITLE
fix: fix bug when stringifying options that contain redis cluster for caching

### DIFF
--- a/src/ConfigCatClient.ts
+++ b/src/ConfigCatClient.ts
@@ -16,7 +16,7 @@ import type { IConfig, PercentageOption, ProjectConfig, Setting, SettingValue } 
 import type { IEvaluationDetails, IRolloutEvaluator, SettingTypeOf } from "./RolloutEvaluator";
 import { RolloutEvaluator, checkSettingsAvailable, evaluate, evaluateAll, evaluationDetailsFromDefaultValue, getTimestampAsDate, handleInvalidReturnValue, isAllowedValue } from "./RolloutEvaluator";
 import type { User } from "./User";
-import { errorToString, isArray, throwError } from "./Utils";
+import { errorToString, isArray, stringifyCircularJSON, throwError } from "./Utils";
 
 /** ConfigCat SDK client. */
 export interface IConfigCatClient extends IProvidesHooks {
@@ -280,7 +280,7 @@ export class ConfigCatClient implements IConfigCatClient {
 
     this.options = options;
 
-    this.options.logger.debug("Initializing ConfigCatClient. Options: " + JSON.stringify(this.options));
+    this.options.logger.debug("Initializing ConfigCatClient. Options: " + stringifyCircularJSON(this.options));
 
     if (!configCatKernel) {
       throw new Error("Invalid 'configCatKernel' value");

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -148,3 +148,16 @@ export function parseFloatStrict(value: unknown): number {
 
   return +value;
 }
+
+export function stringifyCircularJSON(obj: unknown): string {
+  // NOTE: This is a version of JSON.stringify that ignores circular references.
+  // to prevent throwing errors when logging options objects that may contain circular references. eg. redis cluster client for cache
+  const seen = new WeakSet();
+  return JSON.stringify(obj, (k, v) => {
+    if (v !== null && typeof v === "object") {
+      if (seen.has(v)) return;
+      seen.add(v);
+    }
+    return v;
+  });
+}

--- a/test/UtilsTests.ts
+++ b/test/UtilsTests.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import "mocha";
-import { formatStringList, parseFloatStrict, utf8Encode } from "../src/Utils";
+import { formatStringList, parseFloatStrict, stringifyCircularJSON, utf8Encode } from "../src/Utils";
 
 describe("Utils", () => {
 
@@ -76,4 +76,32 @@ describe("Utils", () => {
       assert.strictEqual(actualOutput, expectedOutput);
     });
   }
+
+  describe("stringifyCircularJSON", () => {
+    it("should stringify a simple object", () => {
+      const obj = { a: 1, b: "test" };
+      const result = stringifyCircularJSON(obj);
+      assert.strictEqual(result, '{"a":1,"b":"test"}');
+    });
+
+    it("should stringify a nested object", () => {
+      const obj = { a: 1, b: { c: 2, d: "test" } };
+      const result = stringifyCircularJSON(obj);
+      assert.strictEqual(result, JSON.stringify(obj));
+    });
+
+    it("should handle circular references and remove those properties", () => {
+      const obj: any = { a: 1 };
+      obj.self = obj; // circular reference
+      const result = stringifyCircularJSON(obj);
+      assert.strictEqual(result, '{"a":1}');
+    });
+
+    it("should handle arrays with circular references", () => {
+      const arr: any[] = [1, 2];
+      arr.push(arr); // circular reference
+      const result = stringifyCircularJSON(arr);
+      assert.strictEqual(result, "[1,2,null]");
+    });
+  });
 });


### PR DESCRIPTION
Hi guys, I just want to start by saying thank you for creating this awesome service! My team loves the concept behind it and we're making feature flag implementations via Configcat!

### Describe the purpose of your pull request
One issue we identified while testing with the library is that it will throw an error when we try to instantiate a configCat client using our Redis cluster for caching. It works fine for a single node but does throw an error on [this](https://github.com/configcat/common-js/blob/849f3e748ba05c08b6bed8ec2e47e951456d8b3f/src/ConfigCatClient.ts#L283) line due to `JSON.stringify()`-ing an object with circular references. 

### Related issues (only if applicable)
none

### How to test? (only if applicable)
- Added a `stringifyCircularJSON` method in Util.ts to safely stringify the client's options, does not change any application behavior and all tests are passing.

### Security (only if applicable)
none

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
